### PR TITLE
Rewrite workspace documentation for merged repo layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
 /ros_ws/build/
 /ros_ws/install/
 /ros_ws/log/
-/ros_ws/src/goat_ros_control/
-/ros_ws/src/goat_ros_drivers/
+/ros_ws/src/goat_ros/
 /external/
 /log/
 /.vscode/
 __pycache__/
+/AGENTS.md
+/.agents/
+/notes/

--- a/README.md
+++ b/README.md
@@ -1,35 +1,55 @@
 # goat_racer
 
-`goat_racer` is the top-level orchestration repository for the GOAT workspace.
-It owns shared notes, higher-level docs, Docker-based ROS development
-orchestration, and the canonical `.repos` manifest for component checkouts.
+`goat_racer` is the workspace-orchestration repository for the GOAT racer
+stack. It owns the Docker-based ROS development flow, workspace-level docs and
+notes, and the canonical checkout layout for the nested code repositories.
 
-## Layout
+## Purpose
+
+Use this repo to:
+
+- bootstrap the expected local checkout layout
+- run the shared ROS container workflow
+- build and test the nested GOAT packages together
+- document how the workspace is assembled
+
+This repo does not own the full implementation of every package in the
+workspace. The ROS packages and the VESC transport library live in nested git
+repositories under the paths described below.
+
+## Workspace Layout
 
 - `docker/`
-  Development container definitions.
-- `ros_ws/`
-  The higher-level ROS workspace root. This holds the ROS repositories plus
-  generated build/install/log artifacts.
+  Container and compose files for the ROS development environment.
+- `docs/`
+  Shared documentation templates and workspace-level references.
 - `external/`
-  External library checkouts that are consumed by the ROS workspace but are not
-  tracked by `goat_racer`.
-- `scripts/`
-  Helper scripts for ROS build and test flows across sibling repos.
+  Nested external dependencies that are consumed by the ROS workspace.
 - `notes/`
-  Workspace notes and TODOs.
+  Local notes and planning material for the workspace.
+- `ros_ws/`
+  Workspace root used for nested ROS repositories plus generated build,
+  install, and log artifacts.
+- `scripts/`
+  Operator-facing helpers for common workspace tasks.
 - `goat_racer.repos`
-  Component checkout manifest.
+  Canonical manifest for populating the expected checkout structure.
 
-## Component Repositories
+## Repository Ownership
 
-The current desired checkout layout is:
+The current intended checkout layout is:
 
-- `./external/goat_vesc`
-- `./ros_ws/src/goat_ros_drivers`
-- `./ros_ws/src/goat_ros_control`
+- `external/goat_vesc`
+  Nested `goat_vesc` repository. Owns the reusable VESC transport library,
+  examples, tests, and generated API docs.
+- `ros_ws/src/goat_ros`
+  Nested `goat_ros` repository. Owns the ROS-facing packages, including
+  `goat_vesc_ros` and `goat_teleop`.
 
-## ROS Workflow
+Generated ROS workspace artifacts remain under `ros_ws/build`, `ros_ws/install`,
+and `ros_ws/log`, but those outputs are not the source of truth for the code.
+
+## Workflow
 
 From the `goat_racer` repo root:
 
@@ -37,12 +57,14 @@ From the `goat_racer` repo root:
 scripts/ros up
 scripts/ros build --packages-select goat_vesc goat_vesc_ros goat_teleop
 scripts/ros test --packages-select goat_vesc goat_vesc_ros goat_teleop
+scripts/ros down
 ```
 
-The helper script builds the sibling repos through `colcon --base-paths` and
-stores workspace artifacts under `goat_racer/ros_ws/`.
+The helper script runs `colcon` inside the shared ROS container and targets the
+nested repositories through explicit `--base-paths`. Workspace build artifacts
+are written under `goat_racer/ros_ws/`.
 
-## `.repos`
+## `.repos` Manifest
 
-`goat_racer.repos` encodes the intended local checkout paths so ROS repos land
-inside `ros_ws/src/` and external libraries land inside `external/`.
+`goat_racer.repos` defines the expected checkout paths so the nested repositories
+land in the locations assumed by the Docker workflow and `scripts/ros`.

--- a/README.md
+++ b/README.md
@@ -49,12 +49,69 @@ The current intended checkout layout is:
 Generated ROS workspace artifacts remain under `ros_ws/build`, `ros_ws/install`,
 and `ros_ws/log`, but those outputs are not the source of truth for the code.
 
-## Workflow
+## Prerequisites
+
+Before running the workspace:
+
+- Install Docker with `docker compose` support on the host.
+- Ensure the target VESC serial device is reachable from the host and visible
+  under `/dev`.
+- Ensure the joystick device is reachable from the host, typically
+  `/dev/input/js0`.
+- Use a host account that can run Docker commands.
+
+The shared container already includes `vcstool`, `rosdep`, and the ROS build
+tooling needed for the bootstrap path. The host does not need a native ROS
+installation.
+
+## Fresh Clone To Demo
+
+From a fresh `goat_racer` checkout:
+
+```bash
+git clone https://github.com/ErikLaBrot/goat_racer.git
+cd goat_racer
+scripts/ros bootstrap
+```
+
+`scripts/ros bootstrap` starts the shared ROS container, imports the nested
+repositories defined in `goat_racer.repos`, installs non-source ROS
+dependencies with `rosdep`, and builds the workspace under `ros_ws/`.
+
+Before running the demo, update
+`ros_ws/src/goat_ros/goat_ros_drivers/goat_vesc_ros/config/goat_vesc.yaml` so
+`device_path` points at the correct VESC serial device.
+
+Start the end-to-end controller demo with:
+
+```bash
+scripts/demo
+```
+
+Launch overrides are forwarded directly to the combined ROS launch entrypoint:
+
+```bash
+scripts/demo joy_dev:=/dev/input/js1 deadzone:=0.02
+```
+
+## Demo Success Criteria
+
+The controller demo is considered up when:
+
+- `goat_vesc_ros`, `joy_node`, and `goat_joy` start without launch errors
+- `goat_joy` publishes `goat_vesc_ros/msg/VescControlCommand` on `cmd/vesc`
+- the configured VESC device connects and telemetry topics begin publishing
+- holding the enable button on the joystick causes non-zero commands to reach
+  `cmd/vesc`
+
+If the launch starts but hardware is disconnected, ROS process startup is still
+useful for bringup validation, but the demo is not functionally complete.
+
+## Build And Test Helpers
 
 From the `goat_racer` repo root:
 
 ```bash
-scripts/ros up
 scripts/ros build --packages-select goat_vesc goat_vesc_ros goat_teleop
 scripts/ros test --packages-select goat_vesc goat_vesc_ros goat_teleop
 scripts/ros down

--- a/README.md
+++ b/README.md
@@ -1,127 +1,72 @@
 # goat_racer
 
-`goat_racer` is the workspace-orchestration repository for the GOAT racer
-stack. It owns the Docker-based ROS development flow, workspace-level docs and
-notes, and the canonical checkout layout for the nested code repositories.
+## Description
 
-## Purpose
+`goat_racer` is the top-level orchestration repository for the GOAT racer
+workspace. It owns the shared Docker-based ROS workflow, the nested checkout
+bootstrap, and the top-level helper scripts used to build, test, and run the
+demo.
 
-Use this repo to:
+Detailed package and implementation docs live in the nested repositories, not
+in this README.
 
-- bootstrap the expected local checkout layout
-- run the shared ROS container workflow
-- build and test the nested GOAT packages together
-- document how the workspace is assembled
+## Requirements
 
-This repo does not own the full implementation of every package in the
-workspace. The ROS packages and the VESC transport library live in nested git
-repositories under the paths described below.
+- Docker with `docker compose`
+- Permission to run Docker commands on the host
 
-## Workspace Layout
+The shared container provides ROS tooling, `vcstool`, and `rosdep`, so a host
+ROS install is not required.
 
-- `docker/`
-  Container and compose files for the ROS development environment.
-- `docs/`
-  Shared documentation templates and workspace-level references.
-- `external/`
-  Nested external dependencies that are consumed by the ROS workspace.
-- `notes/`
-  Local notes and planning material for the workspace.
-- `ros_ws/`
-  Workspace root used for nested ROS repositories plus generated build,
-  install, and log artifacts.
-- `scripts/`
-  Operator-facing helpers for common workspace tasks.
-- `goat_racer.repos`
-  Canonical manifest for populating the expected checkout structure.
+## Install
 
-## Repository Ownership
-
-The current intended checkout layout is:
-
-- `external/goat_vesc`
-  Nested `goat_vesc` repository. Owns the reusable VESC transport library,
-  examples, tests, and generated API docs.
-- `ros_ws/src/goat_ros`
-  Nested `goat_ros` repository. Owns the ROS-facing packages, including
-  `goat_vesc_ros` and `goat_teleop`.
-
-Generated ROS workspace artifacts remain under `ros_ws/build`, `ros_ws/install`,
-and `ros_ws/log`, but those outputs are not the source of truth for the code.
-
-## Prerequisites
-
-Before running the workspace:
-
-- Install Docker with `docker compose` support on the host.
-- Ensure the target VESC serial device is reachable from the host and visible
-  under `/dev`.
-- Ensure the joystick device is reachable from the host, typically
-  `/dev/input/js0`.
-- Use a host account that can run Docker commands.
-
-The shared container already includes `vcstool`, `rosdep`, and the ROS build
-tooling needed for the bootstrap path. The host does not need a native ROS
-installation.
-
-## Fresh Clone To Demo
-
-From a fresh `goat_racer` checkout:
+Clone the repo and bootstrap the workspace:
 
 ```bash
 git clone https://github.com/ErikLaBrot/goat_racer.git
 cd goat_racer
-scripts/ros bootstrap
+./scripts/ros bootstrap
 ```
 
-`scripts/ros bootstrap` starts the shared ROS container, imports the nested
-repositories defined in `goat_racer.repos`, installs non-source ROS
-dependencies with `rosdep`, and builds the workspace under `ros_ws/`.
+`scripts/ros bootstrap` imports the nested repositories defined in
+`goat_racer.repos`, installs ROS dependencies, and builds the workspace.
 
 Before running the demo, update
 `ros_ws/src/goat_ros/goat_ros_drivers/goat_vesc_ros/config/goat_vesc.yaml` so
-`device_path` points at the correct VESC serial device.
+`device_path` points at the correct VESC interface.
 
-Start the end-to-end controller demo with:
+## Demo
 
-```bash
-scripts/demo
-```
-
-Launch overrides are forwarded directly to the combined ROS launch entrypoint:
+Run the end-to-end controller demo with:
 
 ```bash
-scripts/demo joy_dev:=/dev/input/js1 deadzone:=0.02
+./scripts/demo
 ```
 
-## Demo Success Criteria
-
-The controller demo is considered up when:
-
-- `goat_vesc_ros`, `joy_node`, and `goat_joy` start without launch errors
-- `goat_joy` publishes `goat_vesc_ros/msg/VescControlCommand` on `cmd/vesc`
-- the configured VESC device connects and telemetry topics begin publishing
-- holding the enable button on the joystick causes non-zero commands to reach
-  `cmd/vesc`
-
-If the launch starts but hardware is disconnected, ROS process startup is still
-useful for bringup validation, but the demo is not functionally complete.
-
-## Build And Test Helpers
-
-From the `goat_racer` repo root:
+Launch overrides are forwarded to the combined ROS launch entrypoint:
 
 ```bash
-scripts/ros build --packages-select goat_vesc goat_vesc_ros goat_teleop
-scripts/ros test --packages-select goat_vesc goat_vesc_ros goat_teleop
-scripts/ros down
+./scripts/demo joy_dev:=/dev/input/js1 deadzone:=0.02
 ```
 
-The helper script runs `colcon` inside the shared ROS container and targets the
-nested repositories through explicit `--base-paths`. Workspace build artifacts
-are written under `goat_racer/ros_ws/`.
+Full demo behavior depends on the target hardware being connected and reachable
+from the host.
 
-## `.repos` Manifest
+## Scripts
 
-`goat_racer.repos` defines the expected checkout paths so the nested repositories
-land in the locations assumed by the Docker workflow and `scripts/ros`.
+- `scripts/ros bootstrap`
+  Populate nested repos, install ROS dependencies, and build the workspace.
+- `scripts/ros build --packages-select goat_vesc goat_vesc_ros goat_teleop`
+  Build the main GOAT workspace packages inside the shared container.
+- `scripts/ros test --packages-select goat_vesc goat_vesc_ros goat_teleop`
+  Build, test, and print test results for the main GOAT workspace packages.
+- `scripts/ros down`
+  Stop and remove the shared ROS container.
+- `scripts/demo`
+  Launch the end-to-end controller demo from the built workspace.
+
+## Notes
+
+- Detailed ROS package docs live in [ros_ws/src/goat_ros/README.md](/home/erik/goat/goat_racer/ros_ws/src/goat_ros/README.md).
+- Detailed `goat_vesc` docs live in [external/goat_vesc/README.md](/home/erik/goat/goat_racer/external/goat_vesc/README.md).
+- The nested checkout manifest lives in [goat_racer.repos](/home/erik/goat/goat_racer/goat_racer.repos).

--- a/docs/templates/cpp_doxygen.md
+++ b/docs/templates/cpp_doxygen.md
@@ -1,0 +1,80 @@
+# C++ Doxygen Template
+
+Use Doxygen for public API documentation in headers.
+
+## Rules
+- Use `/** ... */` comment blocks only.
+- Document public classes, structs, enums, functions, methods, and non-obvious public constants.
+- Prefer documenting declarations in headers rather than duplicating equivalent docs in source files.
+- Use only the approved tags when needed:
+  - `@brief`
+  - `@param`
+  - `@return`
+  - `@note`
+  - `@warning`
+  - `@pre`
+  - `@post`
+- Do not mix `@param` and `\param` styles.
+- Trivial getters, setters, and obvious private helpers do not need Doxygen unless behavior is non-obvious.
+
+## Function Template
+```cpp
+/**
+ * @brief Short summary.
+ *
+ * Optional longer explanation if needed.
+ *
+ * @param name Meaning, units, constraints, or ownership expectations.
+ * @param timeout_s Maximum wait time in seconds.
+ * @return Meaning of the returned value when non-obvious.
+ * @pre Required state before calling.
+ * @post Guaranteed state after successful completion.
+ * @note Side effects, threading assumptions, timing, or call-order caveats.
+ * @warning Safety-critical or easy-to-misuse behavior.
+ */
+bool sendCommand(double name, double timeout_s);
+```
+
+## Class Template
+```cpp
+/**
+ * @brief Short summary of the class purpose.
+ *
+ * Optional explanation of ownership, lifecycle, or operational role when
+ * relevant.
+ */
+class ExampleInterface
+{
+public:
+  /**
+   * @brief Construct the interface with the provided device path.
+   *
+   * @param device_path Stable device path used for connection.
+   */
+  explicit ExampleInterface(const std::string & device_path);
+};
+```
+
+## Enum Template
+```cpp
+/**
+ * @brief Result codes returned by the command path.
+ */
+enum class CommandResult
+{
+  Success,
+  Timeout,
+  InvalidInput,
+};
+```
+
+## Good Patterns
+- Describe purpose, units, ownership, side effects, and preconditions.
+- Keep wording technical and direct.
+- Comment intent and interface contract, not implementation mechanics.
+
+## Avoid
+- Narrating obvious code behavior.
+- Duplicating the same documentation in header and source without reason.
+- Mixing Doxygen tag styles.
+- Explaining private implementation details at API boundaries.

--- a/docs/templates/python_docstring.md
+++ b/docs/templates/python_docstring.md
@@ -1,0 +1,71 @@
+# Python Docstring Template
+
+Use PEP 257 principles with one consistent house format.
+
+## Rules
+- Use triple double quotes for all docstrings.
+- Start with a short summary line.
+- Add a blank line after the summary when additional detail is needed.
+- Only include `Args`, `Returns`, `Raises`, or `Notes` when they add useful information.
+- Do not repeat obvious type information already present in annotations unless units, constraints, shape, or semantic meaning need clarification.
+- Document public modules, classes, and functions. Private helpers may omit docstrings unless behavior is non-obvious.
+
+## Module Template
+```python
+"""Short module summary.
+
+Optional module context if needed. Keep this focused on purpose and scope.
+"""
+```
+
+## Class Template
+```python
+class ExampleController:
+    """Short summary of the class purpose.
+
+    Optional notes about invariants, ownership, lifecycle, or operational behavior
+    when relevant.
+    """
+```
+
+## Function or Method Template
+```python
+def example_function(value: float, timeout_s: float) -> bool:
+    """Evaluate the request against the current limit.
+
+    Optional longer explanation if the behavior, state interaction, or call
+    expectations are not obvious from the name and signature.
+
+    Args:
+        value: Requested value in meters per second.
+        timeout_s: Maximum allowed wait time in seconds.
+
+    Returns:
+        True if the request completes within the allowed limit.
+
+    Raises:
+        ValueError: Requested value is outside the accepted range.
+
+    Notes:
+        Blocks until completion or timeout.
+    """
+```
+
+## Minimal Function Template
+Use this when the summary alone is enough.
+
+```python
+def clamp_command(command: float) -> float:
+    """Clamp the command to the supported output range."""
+```
+
+## Good Patterns
+- Explain units, ranges, ownership, side effects, and preconditions when needed.
+- Summarize what the callable does, not how it does it.
+- Keep wording direct and technical.
+
+## Avoid
+- Line by line implementation commentary.
+- Empty boilerplate sections.
+- Restating the type hint in prose with no added value.
+- Speculative behavior that is not guaranteed by the code.

--- a/docs/templates/ros_package_readme.md
+++ b/docs/templates/ros_package_readme.md
@@ -1,0 +1,46 @@
+# ROS Package README Template
+
+Use this exact section order for ROS package READMEs.
+
+```md
+# <package_name>
+
+## Purpose
+Short description of what the package provides and where it fits in the system.
+
+## Nodes
+### `<node_name>`
+- Purpose: What the node does.
+- Executable: Launch or run target if relevant.
+- Notes: Lifecycle, assumptions, or behavior that matters to operators.
+
+## Topics
+### Subscribed Topics
+- `/example/input` (`example_msgs/msg/Input`): What the node consumes and why.
+
+### Published Topics
+- `/example/output` (`example_msgs/msg/Output`): What the node publishes and why.
+
+## Parameters
+- `example_parameter` (`double`, default: `1.0`): Meaning, units, and effect.
+- `device_path` (`string`): Stable path or interface expected by the node.
+
+## Launch Entry Points
+- `example.launch.py`: When to use it and major launch arguments.
+
+## Dependencies
+- ROS packages
+- External libraries
+- Hardware or runtime assumptions when relevant
+
+## Example Usage
+```bash
+ros2 launch <package_name> example.launch.py
+ros2 run <package_name> <node_name>
+```
+
+## Rules
+- Keep the README operator-facing.
+- Topic names, parameter names, launch files, and examples must match the code.
+- Document user-facing scripts or launch files here or in clearly linked package docs.
+- Prefer concise bullets over long narrative prose.

--- a/docs/templates/script_header.md
+++ b/docs/templates/script_header.md
@@ -1,0 +1,52 @@
+# User-Facing Script Documentation Template
+
+Use this pattern for scripts intended to be run by users or operators.
+
+## Python Script Header Template
+```python
+"""Short script summary.
+
+Purpose:
+    One short paragraph describing what the script is for.
+
+Inputs:
+    Key files, devices, arguments, or environment assumptions.
+
+Outputs:
+    Files created, topics affected, or side effects produced.
+
+Usage:
+    python3 script_name.py --example value
+
+Notes:
+    Operational caveats, destructive behavior, hardware assumptions, or order of
+    operations when relevant.
+"""
+```
+
+## Shell Script Header Template
+```bash
+#!/usr/bin/env bash
+# Short script summary.
+#
+# Purpose:
+#   One short paragraph describing what the script is for.
+#
+# Inputs:
+#   Key arguments, files, devices, or environment assumptions.
+#
+# Outputs:
+#   Files created, state changed, or side effects produced.
+#
+# Usage:
+#   ./script_name.sh --example value
+#
+# Notes:
+#   Operational caveats, destructive behavior, or ordering requirements.
+```
+
+## Rules
+- Keep the header short and useful.
+- Focus on purpose, invocation, inputs, outputs, and operator-facing caveats.
+- Do not narrate implementation details.
+- Throwaway local helper scripts do not need a polished header unless they are intended for reuse.

--- a/goat_racer.repos
+++ b/goat_racer.repos
@@ -3,7 +3,7 @@ repositories:
     type: git
     url: https://github.com/ErikLaBrot/goat_vesc.git
     version: main
-  ros_ws/src:
+  ros_ws/src/goat_ros:
     type: git
     url: https://github.com/ErikLaBrot/goat_ros
     version: main

--- a/goat_racer.repos
+++ b/goat_racer.repos
@@ -3,11 +3,7 @@ repositories:
     type: git
     url: https://github.com/ErikLaBrot/goat_vesc.git
     version: main
-  ros_ws/src/goat_ros_drivers:
+  ros_ws/src:
     type: git
-    url: https://github.com/ErikLaBrot/goat_ros_drivers.git
-    version: main
-  ros_ws/src/goat_ros_control:
-    type: git
-    url: https://github.com/ErikLaBrot/goat_ros_control.git
+    url: https://github.com/ErikLaBrot/goat_ros
     version: main

--- a/notes/todo.md
+++ b/notes/todo.md
@@ -1,4 +1,0 @@
-- Move core/non ros code out of ament_cmake workspace, clean up overall ws
-- Keep ROS repos nested under `goat_racer/ros_ws` and externals under `goat_racer/external`
-- Double check how the vesc ros node interface works. We want a nice interface, maybe custom message
-- Double check the ros joy thingy and make sure it lines up with the vesc node

--- a/scripts/demo
+++ b/scripts/demo
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Run the end-to-end GOAT controller demo.
+#
+# Purpose:
+#   Start the shared ROS container when needed, source the built workspace, and
+#   launch the combined VESC plus joystick teleop demo entrypoint.
+#
+# Inputs:
+#   Optional ROS launch arguments for `goat_teleop controller_demo.launch.py`.
+#
+# Outputs:
+#   Starts the combined ROS demo inside the shared container and streams launch
+#   output to the terminal.
+#
+# Usage:
+#   scripts/demo
+#   scripts/demo joy_dev:=/dev/input/js1 deadzone:=0.02
+#
+# Notes:
+#   Requires a completed `scripts/ros bootstrap` run so the workspace install
+#   setup file exists.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+compose_file="$repo_root/docker/compose.yaml"
+service_name="ros-humble"
+workspace_install="/workspace/goat_racer/ros_ws/install/setup.bash"
+
+is_running() {
+  local services
+  services="$(docker compose -f "$compose_file" ps --status running --services)"
+  [[ "$services" == *"$service_name"* ]]
+}
+
+ensure_running() {
+  if is_running; then
+    return
+  fi
+
+  echo "Container '$service_name' is not running; starting it now."
+  docker compose -f "$compose_file" up -d
+}
+
+if [[ ! -f "$repo_root/ros_ws/install/setup.bash" ]]; then
+  echo "Workspace install is missing. Run scripts/ros bootstrap first." >&2
+  exit 1
+fi
+
+ensure_running
+
+printf 'Running:'
+printf ' %q' docker compose -f "$compose_file" exec "$service_name" bash -lc \
+  "source /opt/ros/humble/setup.bash && source '$workspace_install' && ros2 launch goat_teleop controller_demo.launch.py \"\$@\"" \
+  bash "$@"
+printf '\n'
+
+exec docker compose -f "$compose_file" exec "$service_name" bash -lc \
+  "source /opt/ros/humble/setup.bash && source '$workspace_install' && ros2 launch goat_teleop controller_demo.launch.py \"\$@\"" \
+  bash "$@"

--- a/scripts/ros
+++ b/scripts/ros
@@ -2,25 +2,28 @@
 # Workspace ROS container helper.
 #
 # Purpose:
-#   Start the shared ROS container and run workspace-scoped build or test flows
-#   against the nested GOAT repositories from the `goat_racer` checkout.
+#   Start the shared ROS container and run workspace-scoped bootstrap, build,
+#   or test flows against the nested GOAT repositories from the `goat_racer`
+#   checkout.
 #
 # Inputs:
-#   A subcommand of `up`, `down`, `build`, or `test`, plus any extra colcon
-#   arguments for the build and test paths.
+#   A subcommand of `up`, `down`, `bootstrap`, `build`, or `test`, plus any
+#   extra colcon arguments for the build and test paths.
 #
 # Outputs:
-#   Starts or stops the Docker container and writes build, install, log, and
-#   test artifacts under `ros_ws/`.
+#   Starts or stops the Docker container, optionally populates nested
+#   repositories and ROS dependencies, and writes build, install, log, and test
+#   artifacts under `ros_ws/`.
 #
 # Usage:
 #   scripts/ros up
+#   scripts/ros bootstrap
 #   scripts/ros build --packages-select goat_vesc goat_vesc_ros goat_teleop
 #   scripts/ros test --packages-select goat_vesc goat_vesc_ros goat_teleop
 #
 # Notes:
-#   Build and test commands automatically start the container if needed and
-#   shut it down again on exit.
+#   Bootstrap, build, and test commands automatically start the container if
+#   needed and shut it down again on exit.
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -29,6 +32,9 @@ service_name="ros-humble"
 workspace_root="/workspace/goat_racer"
 workspace_dir="$workspace_root/ros_ws"
 build_root="$workspace_dir"
+manifest_path="$workspace_root/goat_racer.repos"
+legacy_goat_ros_path="$repo_root/ros_ws/src/.git"
+canonical_goat_ros_path="$repo_root/ros_ws/src/goat_ros/.git"
 base_paths=(
   /workspace/goat_racer/external/goat_vesc
   /workspace/goat_racer/ros_ws/src/goat_ros
@@ -36,16 +42,18 @@ base_paths=(
 
 usage() {
   cat <<'EOF'
-Usage: scripts/ros <up|down|build|test> [args...]
+Usage: scripts/ros <up|down|bootstrap|build|test> [args...]
 
 Commands:
   up                  Start the ROS Docker container in detached mode
   down                Stop and remove the ROS Docker container
+  bootstrap           Import nested repos, install ROS deps, and build the workspace
   build [args...]     Ensure the container is running, then run colcon build across the nested ROS workspace
   test [args...]      Ensure the container is running, build, test, and print test results
 
 Examples:
   scripts/ros up
+  scripts/ros bootstrap
   scripts/ros build --packages-select goat_vesc_ros
   scripts/ros test --packages-select goat_vesc_ros
 EOF
@@ -70,6 +78,17 @@ run_in_container() {
 
 cleanup_container() {
   run_compose down
+}
+
+check_workspace_layout() {
+  if [[ -d "$legacy_goat_ros_path" && ! -d "$canonical_goat_ros_path" ]]; then
+    cat >&2 <<'EOF'
+Legacy goat_ros checkout detected at ros_ws/src.
+The canonical nested repository path is ros_ws/src/goat_ros.
+Move the existing checkout into ros_ws/src/goat_ros or remove ros_ws/src and rerun scripts/ros bootstrap.
+EOF
+    exit 1
+  fi
 }
 
 is_running() {
@@ -102,6 +121,7 @@ case "$command" in
     run_compose down
     ;;
   build)
+    check_workspace_layout
     ensure_running
     trap cleanup_container EXIT
     run_in_container \
@@ -109,10 +129,19 @@ case "$command" in
       "$@"
     ;;
   test)
+    check_workspace_layout
     ensure_running
     trap cleanup_container EXIT
     run_in_container \
       "set -eo pipefail; source /opt/ros/humble/setup.bash; cd '$workspace_dir'; colcon --log-base '$build_root/log' build --base-paths ${base_paths[*]} --build-base '$build_root/build' --install-base '$build_root/install' --event-handlers console_direct+; source '$build_root/install/setup.bash'; set -u; colcon --log-base '$build_root/log' test --base-paths ${base_paths[*]} --build-base '$build_root/build' --install-base '$build_root/install' --event-handlers console_direct+ --return-code-on-test-failure \"\$@\"; colcon test-result --test-result-base '$build_root/build' --verbose" \
+      "$@"
+    ;;
+  bootstrap)
+    check_workspace_layout
+    ensure_running
+    trap cleanup_container EXIT
+    run_in_container \
+      "set -eo pipefail; source /opt/ros/humble/setup.bash; set -u; cd '$workspace_root'; git config --global --add safe.directory '$workspace_root'; if [[ -d '$workspace_root/external/goat_vesc/.git' ]]; then git config --global --add safe.directory '$workspace_root/external/goat_vesc'; fi; if [[ -d '$workspace_root/ros_ws/src/goat_ros/.git' ]]; then git config --global --add safe.directory '$workspace_root/ros_ws/src/goat_ros'; fi; vcs import '$workspace_root' < '$manifest_path'; rosdep update; rosdep install --from-paths '$workspace_root/external/goat_vesc' '$workspace_root/ros_ws/src/goat_ros' --ignore-src -t build -t build_export -t buildtool -t buildtool_export -t exec --rosdistro humble -r -y; cd '$workspace_dir'; colcon --log-base '$build_root/log' build --base-paths ${base_paths[*]} --build-base '$build_root/build' --install-base '$build_root/install' --event-handlers console_direct+; echo; echo 'Bootstrap complete. Next step: scripts/demo'" \
       "$@"
     ;;
   *)

--- a/scripts/ros
+++ b/scripts/ros
@@ -1,4 +1,26 @@
 #!/usr/bin/env bash
+# Workspace ROS container helper.
+#
+# Purpose:
+#   Start the shared ROS container and run workspace-scoped build or test flows
+#   against the nested GOAT repositories from the `goat_racer` checkout.
+#
+# Inputs:
+#   A subcommand of `up`, `down`, `build`, or `test`, plus any extra colcon
+#   arguments for the build and test paths.
+#
+# Outputs:
+#   Starts or stops the Docker container and writes build, install, log, and
+#   test artifacts under `ros_ws/`.
+#
+# Usage:
+#   scripts/ros up
+#   scripts/ros build --packages-select goat_vesc goat_vesc_ros goat_teleop
+#   scripts/ros test --packages-select goat_vesc goat_vesc_ros goat_teleop
+#
+# Notes:
+#   Build and test commands automatically start the container if needed and
+#   shut it down again on exit.
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -9,8 +31,7 @@ workspace_dir="$workspace_root/ros_ws"
 build_root="$workspace_dir"
 base_paths=(
   /workspace/goat_racer/external/goat_vesc
-  /workspace/goat_racer/ros_ws/src/goat_ros_drivers
-  /workspace/goat_racer/ros_ws/src/goat_ros_control
+  /workspace/goat_racer/ros_ws/src/goat_ros
 )
 
 usage() {


### PR DESCRIPTION
Closes #2

## Summary
- carry the new documentation templates onto the docs branch
- rewrite the top-level workspace README around the merged goat_ros layout
- document and update scripts/ros so the helper matches the current checkout structure
- align goat_racer.repos with the merged ROS repository checkout path

## Validation
- bash -n scripts/ros
- python3 -m py_compile ros_ws/src/goat_ros/goat_ros_control/goat_teleop_ros/launch/goat_joy.launch.py ros_ws/src/goat_ros/goat_ros_drivers/goat_vesc_ros/launch/goat_vesc.launch.py
- scripts/ros test --packages-select goat_vesc goat_vesc_ros goat_teleop