### PR TITLE
Point demo script at robot launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 `goat_racer` is the top-level orchestration repository for the GOAT racer
 workspace. It owns the shared Docker-based ROS workflow, the nested checkout
 bootstrap, and the top-level helper scripts used to build, test, and run the
-demo.
+canonical robot bringup demo.
 
 Detailed package and implementation docs live in the nested repositories, not
 in this README.
@@ -37,16 +37,22 @@ Before running the demo, update
 
 ## Demo
 
-Run the end-to-end controller demo with:
+Run the canonical robot bringup demo with:
 
 ```bash
 ./scripts/demo
 ```
 
-Launch overrides are forwarded to the combined ROS launch entrypoint:
+Launch overrides are forwarded to `goat_ros_launch robot.launch.py`:
 
 ```bash
 ./scripts/demo joy_dev:=/dev/input/js1 deadzone:=0.02
+```
+
+Record an MCAP rosbag using one of the installed topic profiles:
+
+```bash
+./scripts/demo record:=true record_profile:=slam
 ```
 
 Full demo behavior depends on the target hardware being connected and reachable
@@ -56,14 +62,14 @@ from the host.
 
 - `scripts/ros bootstrap`
   Populate nested repos, install ROS dependencies, and build the workspace.
-- `scripts/ros build --packages-select goat_vesc goat_vesc_ros goat_teleop`
+- `scripts/ros build --packages-up-to goat_ros_launch`
   Build the main GOAT workspace packages inside the shared container.
-- `scripts/ros test --packages-select goat_vesc goat_vesc_ros goat_teleop`
+- `scripts/ros test --packages-select goat_ros_launch`
   Build, test, and print test results for the main GOAT workspace packages.
 - `scripts/ros down`
   Stop and remove the shared ROS container.
 - `scripts/demo`
-  Launch the end-to-end controller demo from the built workspace.
+  Launch `goat_ros_launch robot.launch.py` from the built workspace.
 
 ## Notes
 

--- a/scripts/demo
+++ b/scripts/demo
@@ -1,20 +1,21 @@
 #!/usr/bin/env bash
-# Run the end-to-end GOAT controller demo.
+# Run the canonical GOAT robot bringup demo.
 #
 # Purpose:
 #   Start the shared ROS container when needed, source the built workspace, and
-#   launch the combined VESC plus joystick teleop demo entrypoint.
+#   launch the canonical GOAT robot bringup entrypoint.
 #
 # Inputs:
-#   Optional ROS launch arguments for `goat_teleop controller_demo.launch.py`.
+#   Optional ROS launch arguments for `goat_ros_launch robot.launch.py`.
 #
 # Outputs:
-#   Starts the combined ROS demo inside the shared container and streams launch
+#   Starts the robot bringup demo inside the shared container and streams launch
 #   output to the terminal.
 #
 # Usage:
 #   scripts/demo
 #   scripts/demo joy_dev:=/dev/input/js1 deadzone:=0.02
+#   scripts/demo record:=true record_profile:=slam
 #
 # Notes:
 #   Requires a completed `scripts/ros bootstrap` run so the workspace install
@@ -50,10 +51,10 @@ ensure_running
 
 printf 'Running:'
 printf ' %q' docker compose -f "$compose_file" exec "$service_name" bash -lc \
-  "source /opt/ros/humble/setup.bash && source '$workspace_install' && ros2 launch goat_teleop controller_demo.launch.py \"\$@\"" \
+  "source /opt/ros/humble/setup.bash && source '$workspace_install' && ros2 launch goat_ros_launch robot.launch.py \"\$@\"" \
   bash "$@"
 printf '\n'
 
 exec docker compose -f "$compose_file" exec "$service_name" bash -lc \
-  "source /opt/ros/humble/setup.bash && source '$workspace_install' && ros2 launch goat_teleop controller_demo.launch.py \"\$@\"" \
+  "source /opt/ros/humble/setup.bash && source '$workspace_install' && ros2 launch goat_ros_launch robot.launch.py \"\$@\"" \
   bash "$@"

--- a/scripts/ros
+++ b/scripts/ros
@@ -18,8 +18,8 @@
 # Usage:
 #   scripts/ros up
 #   scripts/ros bootstrap
-#   scripts/ros build --packages-select goat_vesc goat_vesc_ros goat_teleop
-#   scripts/ros test --packages-select goat_vesc goat_vesc_ros goat_teleop
+#   scripts/ros build --packages-up-to goat_ros_launch
+#   scripts/ros test --packages-select goat_ros_launch
 #
 # Notes:
 #   Bootstrap, build, and test commands automatically start the container if
@@ -54,8 +54,8 @@ Commands:
 Examples:
   scripts/ros up
   scripts/ros bootstrap
-  scripts/ros build --packages-select goat_vesc_ros
-  scripts/ros test --packages-select goat_vesc_ros
+  scripts/ros build --packages-up-to goat_ros_launch
+  scripts/ros test --packages-select goat_ros_launch
 EOF
 }
 


### PR DESCRIPTION
Closes #4.

Depends on ErikLaBrot/goat_ros#4 for the installed `goat_ros_launch` package.

## Summary
- Updates `scripts/demo` to launch `goat_ros_launch robot.launch.py` instead of `goat_teleop controller_demo.launch.py`.
- Updates top-level demo docs to describe canonical robot bringup and rosbag recording profile overrides.
- Updates `scripts/ros` examples to build/test against the high-level launch package.

## Validation
- `bash -n scripts/demo`
- `bash -n scripts/ros`
- `git diff --check`
- `./scripts/demo --show-args`
- `./scripts/ros down`