### PR TITLE
Add workspace rosbag storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 /ros_ws/build/
+/ros_ws/bags/*
+!/ros_ws/bags/
+!/ros_ws/bags/README.md
 /ros_ws/install/
 /ros_ws/log/
 /ros_ws/src/goat_ros/

--- a/README.md
+++ b/README.md
@@ -55,6 +55,32 @@ Record an MCAP rosbag using one of the installed topic profiles:
 ./scripts/demo record:=true record_profile:=slam
 ```
 
+Demo recordings default to `ros_ws/bags` on the host, which is mounted inside
+the ROS container as `/workspace/goat_racer/ros_ws/bags`. Use a launch override
+when a single run needs another container-visible directory:
+
+```bash
+./scripts/demo record:=true bag_dir:=/workspace/goat_racer/ros_ws/bags/demo
+```
+
+Use `GOAT_ROSBAG_DIR` when you want to change the top-level default without
+typing `bag_dir` each time. Relative values are resolved from the repo root and
+passed into the container through the workspace mount:
+
+```bash
+GOAT_ROSBAG_DIR=ros_ws/bags/demo ./scripts/demo record:=true
+```
+
+Replay a saved bag from the same mounted location:
+
+```bash
+docker compose -f docker/compose.yaml run --rm ros-humble bash -lc \
+  'source /opt/ros/humble/setup.bash && \
+   source /workspace/goat_racer/ros_ws/install/setup.bash && \
+   ros2 launch goat_ros_launch replay.launch.py \
+     bag_path:=/workspace/goat_racer/ros_ws/bags/<bag_name>'
+```
+
 Full demo behavior depends on the target hardware being connected and reachable
 from the host.
 

--- a/ros_ws/bags/README.md
+++ b/ros_ws/bags/README.md
@@ -1,0 +1,17 @@
+# ROS Bag Storage
+
+This directory is the default host-persistent storage location for rosbags
+recorded through the top-level demo helper.
+
+```bash
+./scripts/demo record:=true
+```
+
+Inside the ROS container, this directory is mounted at:
+
+```text
+/workspace/goat_racer/ros_ws/bags
+```
+
+Recorded bag contents are intentionally ignored by Git. Keep only lightweight
+notes or manifests under version control.

--- a/scripts/demo
+++ b/scripts/demo
@@ -16,6 +16,7 @@
 #   scripts/demo
 #   scripts/demo joy_dev:=/dev/input/js1 deadzone:=0.02
 #   scripts/demo record:=true record_profile:=slam
+#   GOAT_ROSBAG_DIR=ros_ws/bags/demo scripts/demo record:=true
 #
 # Notes:
 #   Requires a completed `scripts/ros bootstrap` run so the workspace install
@@ -25,7 +26,9 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 compose_file="$repo_root/docker/compose.yaml"
 service_name="ros-humble"
+workspace_root="/workspace/goat_racer"
 workspace_install="/workspace/goat_racer/ros_ws/install/setup.bash"
+default_rosbag_dir="ros_ws/bags"
 
 is_running() {
   local services
@@ -47,14 +50,39 @@ if [[ ! -f "$repo_root/ros_ws/install/setup.bash" ]]; then
   exit 1
 fi
 
+launch_args=("$@")
+has_bag_dir=false
+show_args=false
+for arg in "$@"; do
+  if [[ "$arg" == bag_dir:=* ]]; then
+    has_bag_dir=true
+  elif [[ "$arg" == "--show-args" ]]; then
+    show_args=true
+  fi
+done
+
+if [[ "$has_bag_dir" == false && "$show_args" == false ]]; then
+  rosbag_dir="${GOAT_ROSBAG_DIR:-$default_rosbag_dir}"
+  if [[ "$rosbag_dir" == /* ]]; then
+    container_bag_dir="$rosbag_dir"
+    if [[ "$rosbag_dir" == "$workspace_root/"* ]]; then
+      mkdir -p "$repo_root/${rosbag_dir#"$workspace_root"/}"
+    fi
+  else
+    mkdir -p "$repo_root/$rosbag_dir"
+    container_bag_dir="$workspace_root/$rosbag_dir"
+  fi
+  launch_args+=("bag_dir:=$container_bag_dir")
+fi
+
 ensure_running
 
 printf 'Running:'
 printf ' %q' docker compose -f "$compose_file" exec "$service_name" bash -lc \
   "source /opt/ros/humble/setup.bash && source '$workspace_install' && ros2 launch goat_ros_launch robot.launch.py \"\$@\"" \
-  bash "$@"
+  bash "${launch_args[@]}"
 printf '\n'
 
 exec docker compose -f "$compose_file" exec "$service_name" bash -lc \
   "source /opt/ros/humble/setup.bash && source '$workspace_install' && ros2 launch goat_ros_launch robot.launch.py \"\$@\"" \
-  bash "$@"
+  bash "${launch_args[@]}"


### PR DESCRIPTION
Closes #6.

Pairs with ErikLaBrot/goat_ros#6.

## Summary
- Adds a tracked `ros_ws/bags/README.md` marker as the default host-persistent rosbag storage location.
- Ignores recorded bag contents while keeping the storage marker visible in Git.
- Updates `scripts/demo` to pass `bag_dir:=/workspace/goat_racer/ros_ws/bags` by default unless the user already provides `bag_dir:=...`.
- Adds `GOAT_ROSBAG_DIR` as a top-level convenience override for changing the default storage path.
- Documents default storage, one-off `bag_dir` overrides, `GOAT_ROSBAG_DIR`, and replay usage.

## Validation
- `bash -n scripts/demo`
- `git diff --check`
- `./scripts/demo --show-args`
- Fake Docker CLI checks for default `bag_dir`, `GOAT_ROSBAG_DIR`, and explicit `bag_dir` argument behavior
- `./scripts/ros down`