### PR TITLE
Fix Stage 1 devcontainer and helper workflow gaps

### DIFF
--- a/.devcontainer/post_create.sh
+++ b/.devcontainer/post_create.sh
@@ -18,7 +18,7 @@
 # Notes:
 #   Safe to rerun. This script skips workspace dependency installation when the
 #   workspace has not been synced yet.
-set -euo pipefail
+set -eo pipefail
 
 workspace_root="/workspace/goat_racer"
 workspace_src="$workspace_root/ros_ws/src"

--- a/docker/Dockerfile.goat_isaac
+++ b/docker/Dockerfile.goat_isaac
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=arm64v8/ros:humble-ros-base
+ARG BASE_IMAGE=nvcr.io/nvidia/12.6.11-devel:12.6.11-devel-aarch64-ubuntu22.04
 FROM ${BASE_IMAGE}
 
 SHELL ["/bin/bash", "-lc"]
@@ -11,6 +11,11 @@ ENV LANG=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
 ENV ROS_DISTRO=humble
 ENV ROS_WS=/workspace/goat_racer/ros_ws
+ENV CUDA_HOME=/usr/local/cuda
+ENV CUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda
+ENV CUDAToolkit_ROOT=/usr/local/cuda
+ENV PATH=/usr/local/cuda/bin:${PATH}
+ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64:${LD_LIBRARY_PATH}
 
 RUN apt-get update && apt-get install -y \
     ca-certificates \
@@ -20,13 +25,25 @@ RUN apt-get update && apt-get install -y \
     htop \
     iputils-ping \
     locales \
-    python3-colcon-common-extensions \
-    python3-rosdep \
-    python3-vcstool \
+    lsb-release \
     tmux \
     usbutils \
     && locale-gen en_US.UTF-8 \
     && update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key \
+      -o /usr/share/keyrings/ros-archive-keyring.gpg \
+    && release_codename="$(. /etc/os-release && echo "${VERSION_CODENAME}")" \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu ${release_codename} main" \
+      > /etc/apt/sources.list.d/ros2.list
+
+RUN apt-get update && apt-get install -y \
+    python3-colcon-common-extensions \
+    python3-rosdep \
+    python3-vcstool \
+    python3-yaml \
+    ros-humble-ros-base \
     && rm -rf /var/lib/apt/lists/*
 
 RUN curl -fsSL https://isaac.download.nvidia.com/isaac-ros/repos.key \

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -eo pipefail
 
 ros_setup="/opt/ros/${ROS_DISTRO:-humble}/setup.bash"
 workspace_setup="/workspace/goat_racer/ros_ws/install/setup.bash"

--- a/docker/env/amd64.env
+++ b/docker/env/amd64.env
@@ -1,5 +1,5 @@
 # Placeholder amd64 defaults for the GOAT development container.
-BASE_IMAGE=ros:humble-ros-base-jammy
+BASE_IMAGE=nvcr.io/nvidia/tritonserver:24.08-py3
 TARGET_PLATFORM=linux/amd64
 ISAAC_ROS_APT_CHANNEL=release-3
 ISAAC_ROS_APT_SERIES=release-3.0

--- a/docker/env/jetson.env
+++ b/docker/env/jetson.env
@@ -1,5 +1,5 @@
 # Jetson-first defaults for the GOAT development container.
-BASE_IMAGE=arm64v8/ros:humble-ros-base
+BASE_IMAGE=nvcr.io/nvidia/12.6.11-devel:12.6.11-devel-aarch64-ubuntu22.04
 TARGET_PLATFORM=linux/arm64
 ISAAC_ROS_APT_CHANNEL=release-3
 ISAAC_ROS_APT_SERIES=release-3.0

--- a/goat_racer.repos
+++ b/goat_racer.repos
@@ -6,4 +6,4 @@ repositories:
   ros_ws/src/goat_ros:
     type: git
     url: https://github.com/ErikLaBrot/goat_ros
-    version: feat/issue-9-isaac-vslam-bringup
+    version: feat/issue-11-default-sensor-wrapper

--- a/scripts/dev/build_ws.sh
+++ b/scripts/dev/build_ws.sh
@@ -17,14 +17,14 @@
 #
 # Notes:
 #   Requires a synced workspace with at least one ROS package under `ros_ws/src`.
-set -euo pipefail
+set -eo pipefail
 
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/common.sh"
 
 ensure_running
 
 container_script=$(cat <<'EOF'
-set -euo pipefail
+set -eo pipefail
 
 ros_setup="/opt/ros/${ROS_DISTRO:-humble}/setup.bash"
 workspace_dir="/workspace/goat_racer/ros_ws"
@@ -40,6 +40,11 @@ if ! find "$workspace_dir/src" -name package.xml -print -quit | grep -q .; then
 fi
 
 cd "$workspace_dir"
+if [[ -d /usr/local/cuda ]]; then
+  echo "CUDA toolkit detected at ${CUDA_TOOLKIT_ROOT_DIR:-/usr/local/cuda}"
+else
+  echo "CUDA toolkit not found at /usr/local/cuda"
+fi
 colcon build --symlink-install "$@"
 EOF
 )

--- a/scripts/dev/rosdep_install.sh
+++ b/scripts/dev/rosdep_install.sh
@@ -17,14 +17,14 @@
 #
 # Notes:
 #   Requires at least one ROS package under `ros_ws/src`.
-set -euo pipefail
+set -eo pipefail
 
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/common.sh"
 
 ensure_running
 
 container_script=$(cat <<'EOF'
-set -euo pipefail
+set -eo pipefail
 
 ros_setup="/opt/ros/${ROS_DISTRO:-humble}/setup.bash"
 workspace_src="/workspace/goat_racer/ros_ws/src"

--- a/scripts/dev/sync_repos.sh
+++ b/scripts/dev/sync_repos.sh
@@ -28,8 +28,20 @@ container_script=$(cat <<'EOF'
 set -euo pipefail
 
 repo_root="/workspace/goat_racer"
-git config --global --add safe.directory "$repo_root"
 mkdir -p "$repo_root/external" "$repo_root/ros_ws/src"
+
+register_safe_directories() {
+  git config --global --add safe.directory "$repo_root"
+
+  while IFS= read -r git_dir; do
+    git config --global --add safe.directory "$(dirname "$git_dir")"
+  done < <(
+    find "$repo_root/external" "$repo_root/ros_ws/src" \
+      -mindepth 1 -maxdepth 4 -type d -name .git 2>/dev/null | sort
+  )
+}
+
+register_safe_directories
 
 mapfile -t manifests < <(find "$repo_root" -maxdepth 1 -type f -name '*.repos' | sort)
 if [[ ${#manifests[@]} -eq 0 ]]; then
@@ -42,9 +54,7 @@ for manifest in "${manifests[@]}"; do
   vcs import "$repo_root" < "$manifest"
 done
 
-while IFS= read -r git_dir; do
-  git config --global --add safe.directory "$(dirname "$git_dir")"
-done < <(find "$repo_root/external" "$repo_root/ros_ws/src" -mindepth 1 -maxdepth 4 -type d -name .git | sort)
+register_safe_directories
 
 roots=()
 for candidate in "$repo_root/external" "$repo_root/ros_ws/src"; do


### PR DESCRIPTION
## Summary
- switch the Stage 1 devcontainer to a CUDA-bearing NVIDIA base, add ROS Humble on top, and export the CUDA environment Isaac ROS expects
- fix `sync_repos.sh` safe-directory ordering and remove `nounset` hazards from ROS setup sourcing in the Stage 1 helper scripts
- update `goat_racer.repos` to point at the companion `goat_ros` sensor-wrapper fix branch so the default sensor bringup config is reproducible from a clean sync

## Validation
- `bash -n .devcontainer/post_create.sh docker/entrypoint.sh scripts/dev/common.sh scripts/dev/sync_repos.sh scripts/dev/rosdep_install.sh scripts/dev/build_ws.sh scripts/dev/enter.sh scripts/dev/clean_ws.sh scripts/robot/audit_jetson.sh scripts/robot/bootstrap_jetson.sh scripts/ops/record_bag.sh scripts/ops/run_control.sh scripts/ops/run_vslam.sh scripts/ops/run_nvblox.sh`
- `python3 -m py_compile ros_ws/src/goat_ros/goat_ros_launch/launch/sensors.launch.py ros_ws/src/goat_ros/goat_ros_launch/launch/goat_d435_visual_slam.launch.py ros_ws/src/goat_ros/goat_ros_launch/launch/teleop.launch.py`
- `git diff --check`
- `docker compose --env-file docker/env/jetson.env -f docker/compose.dev.yaml config`
- `docker compose --env-file docker/env/jetson.env -f docker/compose.dev.yaml build goat-dev`
- `docker compose --env-file docker/env/jetson.env -f docker/compose.dev.yaml up -d goat-dev`
- `./scripts/dev/sync_repos.sh` to confirm the old safe-directory failure is gone and the script now reaches repo pull/authentication
- `./scripts/dev/rosdep_install.sh` to confirm the old `AMENT_TRACE_SETUP_FILES` nounset failure is gone
- `./scripts/dev/build_ws.sh --packages-select goat_ros_launch` to confirm the old `AMENT_TRACE_SETUP_FILES` nounset failure is gone and CUDA is detected
- `./scripts/dev/enter.sh bash -lc 'source /opt/ros/humble/setup.bash && printf "CUDA_HOME=%s\nCUDA_TOOLKIT_ROOT_DIR=%s\nCUDAToolkit_ROOT=%s\n" "$CUDA_HOME" "$CUDA_TOOLKIT_ROOT_DIR" "$CUDAToolkit_ROOT" && test -d /usr/local/cuda && cd /workspace/goat_racer/ros_ws && colcon build --symlink-install --packages-select isaac_ros_common'`
- `./scripts/dev/enter.sh bash -lc 'source /opt/ros/humble/setup.bash && python3 - <<"PY" ...'` to verify the companion `goat_ros` sensor wrapper config resolves the default launch path, resolves the forwarded Visual SLAM config path, and raises a clear missing-config error

## Notes
- The focused `isaac_ros_common` build now gets past the old `Specify CUDA_TOOLKIT_ROOT_DIR` failure and stops later on missing `vpi` CMake config, which is a different dependency issue.
- `./scripts/dev/sync_repos.sh` now clears the original Git dubious-ownership failure but still needs usable GitHub credentials in this environment for `vcs pull` on the nested repos.
- `./scripts/dev/rosdep_install.sh` and the temporary `goat_ros_launch` build both now avoid the old nounset failure, but this environment still lacks several ROS binary packages such as `ros-humble-realsense2-camera`, so the broader runtime/build workflow is not fully green yet.
- Companion nested-repo PR: `ErikLaBrot/goat_ros#12`.
- This closes #17.
