### PR TITLE
Add GOAT Isaac overlay image workflow

### DIFF
--- a/.isaac_ros_common-config
+++ b/.isaac_ros_common-config
@@ -1,2 +1,15 @@
-CONFIG_IMAGE_KEY=ros2_humble.realsense
+# Resolve the repo-local Docker overlay directory relative to this config file
+# so the checkout can live anywhere on disk.
+_goat_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+CONFIG_IMAGE_KEY=ros2_humble.realsense.goat
 CONFIG_CONTAINER_NAME_SUFFIX=goat_racer
+CONFIG_DOCKER_SEARCH_DIRS=("$_goat_repo_root/docker")
+
+# Optional: set GOAT_BASE_DOCKER_REGISTRY_NAMES to a space-separated list of
+# registry/repository prefixes to check for prebuilt Isaac image layers.
+if [[ -n "${GOAT_BASE_DOCKER_REGISTRY_NAMES:-}" ]]; then
+  read -r -a CONFIG_BASE_DOCKER_REGISTRY_NAMES <<< "${GOAT_BASE_DOCKER_REGISTRY_NAMES}"
+fi
+
+unset _goat_repo_root

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # goat_racer
 
 `goat_racer` is the top-level orchestration repository for the GOAT robot
-workspace. It keeps GOAT-owned ROS packages separate from the vendored Isaac
-ROS source tree and provides a small set of helper scripts that call Isaac
-ROS tooling directly.
+workspace. It keeps GOAT-owned ROS packages in a thin local overlay on top of
+an Isaac ROS RealSense image extended with a small GOAT-specific Docker layer.
 
 ## Requirements
 
@@ -12,7 +11,7 @@ ROS tooling directly.
 - `vcs`
 - Permission to run Docker commands on the host
 
-## Developer Workflow
+## Deployment Workflow
 
 1. Clone the repository.
 2. Sync nested repositories:
@@ -21,33 +20,19 @@ ROS tooling directly.
    ./scripts/dev/sync_repos.sh
    ```
 
-3. Open the repo in the VS Code devcontainer or attach from a terminal:
+3. Enter the GOAT Isaac development container:
 
    ```bash
    ./scripts/dev/enter.sh
    ```
 
-4. Install workspace dependencies:
-
-   ```bash
-   ./scripts/dev/rosdep_install.sh
-   ```
-
-5. Build the workspace:
+4. Build the GOAT overlay packages:
 
    ```bash
    ./scripts/dev/build_ws.sh
    ```
 
-6. Launch Visual SLAM:
-
-   Upstream Isaac ROS RealSense example:
-
-   ```bash
-   ros2 launch isaac_ros_visual_slam isaac_ros_visual_slam_realsense.launch.py
-   ```
-
-   GOAT sensor wrapper path:
+5. Launch the default GOAT D435 Visual SLAM demo:
 
    ```bash
    ./scripts/ops/run_vslam.sh
@@ -56,17 +41,47 @@ ROS tooling directly.
 `./scripts/dev/enter.sh` is the primary way to enter the dev environment. It
 sources the repo-owned [.isaac_ros_common-config](/home/goat/goat/goat_racer/.isaac_ros_common-config)
 and then execs upstream `isaac_ros_common/scripts/run_dev.sh -d <repo-root>`.
-Compose and devcontainer assets may remain in the repo for later work, but they
-are not the Stage 2A primary workflow.
+The default image key is `ros2_humble.realsense.goat`, which adds the heavy
+Isaac ROS Visual SLAM packages to the GOAT image layer instead of source
+building them in the normal workspace.
+
+`./scripts/dev/build_ws.sh` builds GOAT-owned packages only from
+`ros_ws/src/goat_ros` and `external/goat_vesc`. The default VSLAM demo is the
+GOAT D435 stereo-only path: infrared stereo enabled, color and depth disabled,
+and IMU fusion off unless you opt in explicitly.
+
+`./scripts/dev/rosdep_install.sh` remains available as a fallback helper when
+GOAT package dependencies change, but it is not part of the normal fresh-Jetson
+happy path.
+
+## Image Helpers
+
+Build or publish the GOAT image explicitly when needed:
+
+```bash
+./scripts/dev/build_goat_image.sh
+./scripts/dev/tag_goat_image.sh
+GOAT_IMAGE_REGISTRY=ghcr.io/example ./scripts/dev/push_goat_image.sh
+```
+
+These scripts use env-driven naming:
+
+- `GOAT_IMAGE_ARCH` defaults to `aarch64`
+- `GOAT_IMAGE_KEY` defaults to `ros2_humble.realsense.goat`
+- `GOAT_IMAGE_NAME` defaults to `isaac_ros_dev-${GOAT_IMAGE_ARCH}-goat_racer`
+- `GOAT_IMAGE_REGISTRY`, `GOAT_IMAGE_REPOSITORY`, and `GOAT_IMAGE_TAG` are optional
 
 ## Layout
 
 - `ros_ws/` is the main ROS workspace root.
 - `ros_ws/src/goat_ros` is reserved for GOAT ROS packages.
-- `ros_ws/src/isaac_ros` is reserved for Isaac ROS source checkouts.
+- `ros_ws/src/isaac_ros` keeps the upstream `isaac_ros_common` source checkout
+  used by `run_dev.sh`.
 - `external/` is reserved for non-ROS project dependencies.
-- `docker/` and `.devcontainer/` contain secondary Stage 1 assets that are not
-  the primary Stage 2A workflow.
+- `docker/` contains the GOAT image overlay layer used by Isaac ROS image
+  resolution.
+- `.devcontainer/` remains a secondary workflow and is not the source of truth
+  for the supported Jetson deployment path.
 
 ## Additional Docs
 

--- a/docker/Dockerfile.goat
+++ b/docker/Dockerfile.goat
@@ -1,0 +1,10 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+SHELL ["/bin/bash", "-c"]
+
+RUN --mount=type=cache,target=/var/cache/apt \
+    apt-get update && apt-get install -y \
+    ros-humble-isaac-ros-examples \
+    ros-humble-isaac-ros-visual-slam \
+    && rm -rf /var/lib/apt/lists/*

--- a/docs/devcontainer_workflow.md
+++ b/docs/devcontainer_workflow.md
@@ -6,11 +6,17 @@ The supported Stage 2A path is:
 
 1. `./scripts/dev/sync_repos.sh`
 2. `./scripts/dev/enter.sh`
-3. `./scripts/dev/rosdep_install.sh`
-4. `./scripts/dev/build_ws.sh`
+3. `./scripts/dev/build_ws.sh`
+4. `./scripts/ops/run_vslam.sh`
 
 Those repo helpers call Isaac ROS tooling directly. They do not rely on Docker
 Compose as the primary container workflow.
+
+`./scripts/dev/enter.sh` launches the `ros2_humble.realsense.goat` image key,
+which resolves the GOAT overlay layer from `docker/Dockerfile.goat`.
+
+`./scripts/dev/rosdep_install.sh` still exists as a fallback helper when GOAT
+package dependencies change, but it is no longer part of the normal happy path.
 
 ## Current Status
 
@@ -28,6 +34,6 @@ a secondary workflow. The supported command-line flow still uses
 ## Workspace Layout
 
 - `ros_ws/src/goat_ros` for project ROS packages
-- `ros_ws/src/isaac_ros` for Isaac ROS source repositories
+- `ros_ws/src/isaac_ros` for the upstream `isaac_ros_common` checkout
 - `external/` for non-ROS dependencies
 - `ros_ws/bags` for rosbag output when you choose to record manually

--- a/docs/isaac_ros_visual_slam.md
+++ b/docs/isaac_ros_visual_slam.md
@@ -2,9 +2,10 @@
 
 ## Purpose
 
-This is the Stage 2A baseline bringup guide for Isaac ROS Visual SLAM. The goal
-is to use Isaac ROS tooling directly, keep the workspace readable, and document
-one clean upstream example path plus one clean GOAT wrapper path.
+This is the supported GOAT bringup guide for Isaac ROS Visual SLAM on a fresh
+Jetson. The goal is to keep the normal workflow on `run_dev.sh`, move the heavy
+Isaac ROS dependencies into the GOAT image layer, and finish with the GOAT
+D435 stereo-only VSLAM demo.
 
 ## Requirements
 
@@ -14,29 +15,49 @@ one clean upstream example path plus one clean GOAT wrapper path.
 - `vcs`
 - D435 connected before launching the container
 
-## Prepare The Workspace
+## Fresh-Jetson Happy Path
 
 From the repo root:
 
 ```bash
 ./scripts/dev/sync_repos.sh
-./scripts/dev/rosdep_install.sh
+./scripts/dev/enter.sh
 ./scripts/dev/build_ws.sh
+./scripts/ops/run_vslam.sh
 ```
 
-Enter the Isaac ROS dev container when you want an interactive shell:
+`./scripts/dev/enter.sh` remains the primary container workflow. It sources the
+repo-owned [.isaac_ros_common-config](/home/goat/goat/goat_racer/.isaac_ros_common-config)
+and then calls upstream `isaac_ros_common/scripts/run_dev.sh -d /path/to/repo`.
+The configured image key is `ros2_humble.realsense.goat`, which resolves the
+GOAT Docker layer in `docker/Dockerfile.goat`.
+
+## Default Demo Behavior
+
+- `./scripts/ops/run_vslam.sh` is the normal deployment and demo entrypoint.
+- It launches `goat_ros_launch/sensors.launch.py`, which defaults to the GOAT
+  D435 Visual SLAM wrapper from `goat_ros_launch/config/sensors.yaml`.
+- The default GOAT D435 profile is stereo-only:
+  - infrared stereo enabled
+  - color disabled
+  - depth disabled
+  - IMU fusion disabled unless you pass `enable_imu_fusion:=true`
+- `./scripts/dev/build_ws.sh` builds GOAT-owned packages only. It does not
+  source-build `isaac_ros_visual_slam` in the regular workspace.
+
+CLI overrides still work when needed:
 
 ```bash
-./scripts/dev/enter.sh
+./scripts/ops/run_vslam.sh sensor_launch_arguments:="enable_imu_fusion:=true"
 ```
 
-`./scripts/dev/enter.sh` sources the repo-owned
-[.isaac_ros_common-config](/home/goat/goat/goat_racer/.isaac_ros_common-config)
-and then calls upstream `isaac_ros_common/scripts/run_dev.sh -d /path/to/repo`.
+`./scripts/dev/rosdep_install.sh` is kept as a fallback helper for future GOAT
+dependency changes, but it is not required for the default flow above.
 
-## Launch Target 1: Upstream Isaac ROS Example
+## Optional Debug Check
 
-Inside the container:
+If you want to confirm the preinstalled Isaac packages directly inside the
+container, run:
 
 ```bash
 source /opt/ros/humble/setup.bash
@@ -44,53 +65,29 @@ source /workspaces/isaac_ros-dev/ros_ws/install/setup.bash
 ros2 launch isaac_ros_visual_slam isaac_ros_visual_slam_realsense.launch.py
 ```
 
-This is the supported Isaac ROS RealSense example path and should be the first
-baseline check when you want to confirm the Isaac side is healthy.
-
-## Launch Target 2: GOAT Sensor Wrapper
-
-Inside the container:
-
-```bash
-source /opt/ros/humble/setup.bash
-source /workspaces/isaac_ros-dev/ros_ws/install/setup.bash
-ros2 launch goat_ros_launch sensors.launch.py
-```
-
-Or from the host:
-
-```bash
-./scripts/ops/run_vslam.sh
-```
-
-The GOAT wrapper uses the package-installed default config at
-`goat_ros_launch/config/sensors.yaml` and keeps CLI override support:
-
-```bash
-ros2 launch goat_ros_launch sensors.launch.py \
-  config_file:=/path/to/alternate_sensors.yaml
-```
-
-If you pass a bad config path, `sensors.launch.py` should fail clearly before it
-tries to include the wrapped launch file.
+Treat this as an Isaac-side debug check rather than the normal GOAT deployment
+path.
 
 ## What To Check
 
 - The D435 appears inside the Isaac ROS container.
 - `/visual_slam/tracking/odometry` publishes once the camera is moving.
-- The upstream example starts without repo-specific wrapper logic.
 - The GOAT wrapper starts with no extra launch arguments.
+- `ros2 pkg prefix isaac_ros_visual_slam` resolves from the installed runtime
+  packages in the image rather than a source checkout.
 
 Quick spot checks:
 
 ```bash
 ros2 topic list | grep visual_slam
 ros2 topic echo /visual_slam/tracking/odometry --once
+ros2 pkg prefix isaac_ros_visual_slam
+ros2 pkg prefix isaac_ros_examples
 ```
 
 ## Limits
 
-- This stage does not make teleop, VESC, robot-level bringup, rosbag helpers,
-  or VIO part of the primary success path.
+- Full robot bringup, teleop, rosbag helpers, and VIO remain available, but the
+  primary success path for this stage ends with `./scripts/ops/run_vslam.sh`.
 - The GOAT D435 wrapper keeps zeroed default static transforms for bench
   testing; replace them with measured transforms before robot evaluation.

--- a/docs/version_matrix.md
+++ b/docs/version_matrix.md
@@ -13,5 +13,6 @@ explicitly so they can be pinned later without guessing.
 | Isaac ROS apt lane | `release-3` / `release-3.0` |
 | JetPack / L4T lane | JetPack 6.x / L4T r36.x |
 | CUDA / TensorRT lane | Inherited from the selected base image and Isaac ROS lane; exact project pin TBD |
-| Default Jetson base image | `arm64v8/ros:humble-ros-base` with the Isaac ROS apt lane enabled |
-| Placeholder amd64 base image | `ros:humble-ros-base-jammy` with the Isaac ROS apt lane enabled |
+| Default image key | `ros2_humble.realsense.goat` |
+| Default Jetson base image | Isaac ROS `realsense` image plus GOAT `Dockerfile.goat` overlay |
+| Placeholder amd64 base image | Same layered image flow, architecture override not yet the primary lane |

--- a/isaac_ros.repos
+++ b/isaac_ros.repos
@@ -3,7 +3,3 @@ repositories:
     type: git
     url: https://github.com/NVIDIA-ISAAC-ROS/isaac_ros_common.git
     version: release-3.2
-  ros_ws/src/isaac_ros/isaac_ros_visual_slam:
-    type: git
-    url: https://github.com/NVIDIA-ISAAC-ROS/isaac_ros_visual_slam.git
-    version: release-3.2

--- a/scripts/dev/_goat_image_common.sh
+++ b/scripts/dev/_goat_image_common.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Shared helpers for GOAT Isaac image management scripts.
+#
+# Purpose:
+#   Load the repo-owned Isaac ROS config and compute the local and remote image
+#   references used by the GOAT image build, tag, and push helpers.
+#
+# Inputs:
+#   Optional GOAT_IMAGE_* environment variables.
+#
+# Outputs:
+#   Exports shell variables for GOAT image naming and validates required tools.
+#
+# Usage:
+#   source ./scripts/dev/_goat_image_common.sh
+#
+# Notes:
+#   Intended to be sourced by sibling scripts under scripts/dev.
+set -euo pipefail
+
+goat_image_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+goat_image_config_file="$goat_image_repo_root/.isaac_ros_common-config"
+goat_image_layers_script="$goat_image_repo_root/ros_ws/src/isaac_ros/isaac_ros_common/scripts/build_image_layers.sh"
+
+if [[ ! -f "$goat_image_layers_script" ]]; then
+  echo "Isaac ROS build_image_layers.sh was not found at $goat_image_layers_script." >&2
+  echo "Run ./scripts/dev/sync_repos.sh first." >&2
+  return 1
+fi
+
+if [[ -f "$goat_image_config_file" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$goat_image_config_file"
+  set +a
+fi
+
+GOAT_IMAGE_ARCH="${GOAT_IMAGE_ARCH:-aarch64}"
+GOAT_IMAGE_KEY="${GOAT_IMAGE_KEY:-ros2_humble.realsense.goat}"
+GOAT_IMAGE_NAME="${GOAT_IMAGE_NAME:-isaac_ros_dev-${GOAT_IMAGE_ARCH}-goat_racer}"
+GOAT_IMAGE_REPOSITORY="${GOAT_IMAGE_REPOSITORY:-$GOAT_IMAGE_NAME}"
+GOAT_IMAGE_TAG="${GOAT_IMAGE_TAG:-latest}"
+
+goat_image_key_with_arch="${GOAT_IMAGE_ARCH}.${GOAT_IMAGE_KEY}"
+goat_remote_image_ref="${GOAT_IMAGE_REPOSITORY}:${GOAT_IMAGE_TAG}"
+if [[ -n "${GOAT_IMAGE_REGISTRY:-}" ]]; then
+  goat_remote_image_ref="${GOAT_IMAGE_REGISTRY}/${goat_remote_image_ref}"
+fi

--- a/scripts/dev/build_goat_image.sh
+++ b/scripts/dev/build_goat_image.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Build the GOAT Isaac overlay image locally.
+#
+# Purpose:
+#   Build the layered GOAT Isaac image on top of Isaac ROS RealSense using the
+#   repo-owned config and Docker search path.
+#
+# Inputs:
+#   Optional GOAT_IMAGE_ARCH, GOAT_IMAGE_KEY, and GOAT_IMAGE_NAME environment
+#   variables.
+#
+# Outputs:
+#   Produces or refreshes the local Docker image used by ./scripts/dev/enter.sh.
+#
+# Usage:
+#   ./scripts/dev/build_goat_image.sh
+#
+# Notes:
+#   Requires ros_ws/src/isaac_ros/isaac_ros_common to be present.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$script_dir/_goat_image_common.sh"
+
+exec "$goat_image_layers_script" \
+  --image_key "$goat_image_key_with_arch" \
+  --image_name "$GOAT_IMAGE_NAME"

--- a/scripts/dev/build_ws.sh
+++ b/scripts/dev/build_ws.sh
@@ -16,7 +16,8 @@
 #   ./scripts/dev/build_ws.sh --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo
 #
 # Notes:
-#   Defaults to the minimum Stage 2A package set for Visual SLAM bringup.
+#   Builds the GOAT overlay packages only and does not source-build Isaac ROS
+#   Visual SLAM in the regular workspace flow.
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -24,15 +25,41 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 exec "$repo_root/scripts/dev/enter.sh" -lc '
 set -e
 
-workspace_dir="/workspaces/isaac_ros-dev/ros_ws"
+repo_root="/workspaces/isaac_ros-dev"
+workspace_dir="$repo_root/ros_ws"
+goat_ros_dir="$workspace_dir/src/goat_ros"
+goat_vesc_dir="$repo_root/external/goat_vesc"
 
 source /opt/ros/humble/setup.bash
 
-if ! find "$workspace_dir/src" -name package.xml -print -quit | grep -q .; then
-  echo "No ROS packages found under $workspace_dir/src. Run ./scripts/dev/sync_repos.sh first." >&2
+if [[ ! -d "$goat_ros_dir" ]]; then
+  echo "GOAT ROS source tree not found at $goat_ros_dir. Run ./scripts/dev/sync_repos.sh first." >&2
   exit 1
 fi
 
-cd "$workspace_dir"
-colcon build --symlink-install --packages-up-to isaac_ros_visual_slam goat_ros_launch "$@"
+if [[ ! -d "$goat_vesc_dir" ]]; then
+  echo "GOAT VESC source tree not found at $goat_vesc_dir. Run ./scripts/dev/sync_repos.sh first." >&2
+  exit 1
+fi
+
+mapfile -t goat_packages < <(
+  colcon list \
+    --base-paths "$goat_vesc_dir" "$goat_ros_dir" \
+    --names-only
+)
+
+if [[ ${#goat_packages[@]} -eq 0 ]]; then
+  echo "No GOAT packages found under $goat_ros_dir or $goat_vesc_dir." >&2
+  exit 1
+fi
+
+cd "$repo_root"
+colcon build \
+  --base-paths "$goat_vesc_dir" "$goat_ros_dir" \
+  --build-base "$workspace_dir/build" \
+  --install-base "$workspace_dir/install" \
+  --log-base "$workspace_dir/log" \
+  --symlink-install \
+  --packages-select "${goat_packages[@]}" \
+  "$@"
 ' bash "$@"

--- a/scripts/dev/push_goat_image.sh
+++ b/scripts/dev/push_goat_image.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Push the GOAT Isaac image to a remote registry.
+#
+# Purpose:
+#   Tag the locally built GOAT Isaac image with the requested remote reference
+#   and push it to a registry.
+#
+# Inputs:
+#   Optional GOAT_IMAGE_ARCH, GOAT_IMAGE_KEY, GOAT_IMAGE_NAME,
+#   GOAT_IMAGE_REGISTRY, GOAT_IMAGE_REPOSITORY, and GOAT_IMAGE_TAG environment
+#   variables.
+#
+# Outputs:
+#   Pushes the tagged GOAT Isaac image to the configured Docker registry.
+#
+# Usage:
+#   GOAT_IMAGE_REGISTRY=ghcr.io/example ./scripts/dev/push_goat_image.sh
+#
+# Notes:
+#   Requires GOAT_IMAGE_REGISTRY to be set for remote publication.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$script_dir/_goat_image_common.sh"
+
+if [[ -z "${GOAT_IMAGE_REGISTRY:-}" ]]; then
+  echo "GOAT_IMAGE_REGISTRY must be set before pushing the GOAT image." >&2
+  exit 1
+fi
+
+"$script_dir/tag_goat_image.sh"
+docker push "$goat_remote_image_ref"

--- a/scripts/dev/tag_goat_image.sh
+++ b/scripts/dev/tag_goat_image.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Tag the local GOAT Isaac image for publication.
+#
+# Purpose:
+#   Apply a registry/repository/tag reference to the locally built GOAT Isaac
+#   image without pushing it.
+#
+# Inputs:
+#   Optional GOAT_IMAGE_ARCH, GOAT_IMAGE_KEY, GOAT_IMAGE_NAME,
+#   GOAT_IMAGE_REGISTRY, GOAT_IMAGE_REPOSITORY, and GOAT_IMAGE_TAG environment
+#   variables.
+#
+# Outputs:
+#   Creates or refreshes a Docker tag for the GOAT Isaac image.
+#
+# Usage:
+#   ./scripts/dev/tag_goat_image.sh
+#
+# Notes:
+#   Defaults to tagging the local image as <repository>:latest when no registry
+#   settings are supplied.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$script_dir/_goat_image_common.sh"
+
+if ! docker image inspect "$GOAT_IMAGE_NAME" >/dev/null 2>&1; then
+  echo "Local GOAT image not found: $GOAT_IMAGE_NAME" >&2
+  echo "Run ./scripts/dev/build_goat_image.sh first." >&2
+  exit 1
+fi
+
+docker tag "$GOAT_IMAGE_NAME" "$goat_remote_image_ref"
+echo "Tagged $GOAT_IMAGE_NAME as $goat_remote_image_ref"

--- a/scripts/ops/run_vslam.sh
+++ b/scripts/ops/run_vslam.sh
@@ -2,16 +2,16 @@
 # Launch the GOAT Visual SLAM sensor wrapper inside the Isaac ROS container.
 #
 # Purpose:
-#   Provide a thin operator-facing helper for the Stage 2A GOAT Visual SLAM
-#   path after the workspace has been built.
+#   Provide the primary operator-facing GOAT Visual SLAM demo path after the
+#   workspace has been built.
 #
 # Inputs:
 #   Optional extra `ros2 launch` arguments forwarded to
 #   `goat_ros_launch/sensors.launch.py`.
 #
 # Outputs:
-#   Starts the GOAT D435 Visual SLAM launch path in the Isaac ROS dev
-#   container.
+#   Starts the default GOAT D435 stereo-only Visual SLAM launch path in the
+#   Isaac ROS dev container.
 #
 # Usage:
 #   ./scripts/ops/run_vslam.sh

--- a/scripts/robot/bootstrap_jetson.sh
+++ b/scripts/robot/bootstrap_jetson.sh
@@ -1,29 +1,51 @@
 #!/usr/bin/env bash
-# Describe the intended Jetson bootstrap flow for Stage 1.
+# Print the supported fresh-Jetson GOAT deployment flow.
 #
 # Purpose:
-#   Reserve the Jetson bootstrap entrypoint while the repo layout and container
-#   workflow are being established.
+#   Summarize the expected host baseline and the non-mutating command sequence
+#   for the GOAT Isaac overlay workflow on a newly provisioned Jetson.
 #
 # Inputs:
 #   None.
 #
 # Outputs:
-#   Prints the current manual bootstrap checklist.
+#   Prints the current supported deployment checklist and relevant docs.
 #
 # Usage:
 #   ./scripts/robot/bootstrap_jetson.sh
 #
 # Notes:
-#   This script does not make host changes yet.
+#   This script does not make host changes.
 set -euo pipefail
 
-cat <<'EOF'
-Stage 1 does not automate Jetson bootstrap yet.
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
-Recommended manual baseline:
-1. Install Docker Engine and NVIDIA Container Toolkit support.
-2. Ensure Jetson NVIDIA container runtime support is available on the host.
-3. Run ./scripts/robot/audit_jetson.sh to capture the current host state.
-4. Start the Isaac ROS dev container with ./scripts/dev/enter.sh.
+cat <<EOF
+Supported GOAT Jetson deployment flow
+
+Expected host baseline:
+1. Jetson host with Docker and NVIDIA container runtime support.
+2. git-lfs and vcs installed on the host.
+3. D435 connected before launching the container.
+
+Recommended verification:
+- ./scripts/robot/audit_jetson.sh
+
+Fresh checkout workflow:
+1. git clone <goat_racer_repo>
+2. cd goat_racer
+3. ./scripts/dev/sync_repos.sh
+4. ./scripts/dev/enter.sh
+5. ./scripts/dev/build_ws.sh
+6. ./scripts/ops/run_vslam.sh
+
+Optional maintenance commands:
+- ./scripts/dev/build_goat_image.sh
+- ./scripts/dev/tag_goat_image.sh
+- ./scripts/dev/push_goat_image.sh
+- ./scripts/dev/rosdep_install.sh  # fallback when GOAT dependencies change
+
+Primary docs:
+- $repo_root/README.md
+- $repo_root/docs/isaac_ros_visual_slam.md
 EOF


### PR DESCRIPTION
## Summary
- switch the repo-owned Isaac image key to `ros2_humble.realsense.goat`
- add a GOAT overlay Docker layer and image helper scripts
- build only GOAT-owned packages in the regular workspace flow
- rewrite the Jetson/VSLAM docs around `enter.sh` + `run_vslam.sh`

## Testing
- `bash -n .isaac_ros_common-config scripts/dev/build_ws.sh scripts/dev/_goat_image_common.sh scripts/dev/build_goat_image.sh scripts/dev/tag_goat_image.sh scripts/dev/push_goat_image.sh scripts/ops/run_vslam.sh scripts/robot/bootstrap_jetson.sh`
- verified config resolution for `CONFIG_IMAGE_KEY=ros2_humble.realsense.goat`
- verified `isaac_ros_visual_slam` was removed from `isaac_ros.repos`