### PR TITLE
Align Isaac ROS tooling checkout path

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ development container to simplify setup.
    ```
 
 `./scripts/dev/enter.sh` is the primary way to enter the dev environment. It
-execs upstream `src/isaac_ros_common/scripts/run_dev.sh -d <repo-root>`.
+execs upstream `ros_ws/src/isaac_ros_common/scripts/run_dev.sh -d <repo-root>`.
 `./scripts/dev/sync_repos.sh` ensures the standard Isaac ROS config file exists
-at `src/isaac_ros_common/scripts/.isaac_ros_common-config` with the upstream
-`ros2_humble.realsense` image key.
+at `ros_ws/src/isaac_ros_common/scripts/.isaac_ros_common-config` with the
+upstream `ros2_humble.realsense` image key.
 
 `./scripts/dev/build_ws.sh` builds GOAT-owned packages only from
 `ros_ws/src/goat_ros` and `external/goat_vesc`. `./scripts/dev/rosdep_install.sh`
@@ -61,8 +61,8 @@ source checkout.
 
 - `ros_ws/` is the main ROS workspace root.
 - `ros_ws/src/goat_ros` is reserved for GOAT ROS packages.
-- `src/isaac_ros_common` is the vendored upstream Isaac ROS tooling checkout
-  used by `run_dev.sh`.
+- `ros_ws/src/isaac_ros_common` is the vendored upstream Isaac ROS tooling
+  checkout used by `run_dev.sh`.
 - `external/` is reserved for non-ROS project dependencies.
 - `.devcontainer/` remains a secondary workflow and is not the source of truth
   for the supported Jetson deployment path.

--- a/docs/devcontainer_workflow.md
+++ b/docs/devcontainer_workflow.md
@@ -14,9 +14,9 @@ Those repo helpers call Isaac ROS tooling directly. They do not rely on Docker
 Compose as the primary container workflow.
 
 `./scripts/dev/enter.sh` delegates to the vendored upstream
-`src/isaac_ros_common/scripts/run_dev.sh`. `./scripts/dev/sync_repos.sh`
+`ros_ws/src/isaac_ros_common/scripts/run_dev.sh`. `./scripts/dev/sync_repos.sh`
 ensures the standard Isaac ROS config file exists at
-`src/isaac_ros_common/scripts/.isaac_ros_common-config` with
+`ros_ws/src/isaac_ros_common/scripts/.isaac_ros_common-config` with
 `CONFIG_IMAGE_KEY=ros2_humble.realsense`.
 
 ## Current Status
@@ -34,7 +34,7 @@ a secondary workflow. The supported command-line flow still uses
 
 ## Workspace Layout
 
-- `src/isaac_ros_common` for the upstream Isaac ROS tooling checkout
+- `ros_ws/src/isaac_ros_common` for the upstream Isaac ROS tooling checkout
 - `ros_ws/src/goat_ros` for project ROS packages
 - `external/` for non-ROS dependencies
 - `ros_ws/bags` for rosbag output when you choose to record manually

--- a/docs/isaac_ros_visual_slam.md
+++ b/docs/isaac_ros_visual_slam.md
@@ -28,9 +28,9 @@ From the repo root:
 ```
 
 `./scripts/dev/enter.sh` remains the primary container workflow. It calls
-upstream `src/isaac_ros_common/scripts/run_dev.sh -d /path/to/repo`.
+upstream `ros_ws/src/isaac_ros_common/scripts/run_dev.sh -d /path/to/repo`.
 `./scripts/dev/sync_repos.sh` ensures the standard Isaac ROS config file exists
-at `src/isaac_ros_common/scripts/.isaac_ros_common-config` with
+at `ros_ws/src/isaac_ros_common/scripts/.isaac_ros_common-config` with
 `CONFIG_IMAGE_KEY=ros2_humble.realsense`.
 
 ## Default Demo Behavior

--- a/isaac_ros.repos
+++ b/isaac_ros.repos
@@ -1,5 +1,5 @@
 repositories:
-  src/isaac_ros_common:
+  ros_ws/src/isaac_ros_common:
     type: git
     url: https://github.com/NVIDIA-ISAAC-ROS/isaac_ros_common.git
     version: release-3.2

--- a/scripts/dev/enter.sh
+++ b/scripts/dev/enter.sh
@@ -22,7 +22,7 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-run_dev_script="$repo_root/src/isaac_ros_common/scripts/run_dev.sh"
+run_dev_script="$repo_root/ros_ws/src/isaac_ros_common/scripts/run_dev.sh"
 
 if [[ ! -f "$run_dev_script" ]]; then
   echo "Isaac ROS run_dev.sh was not found at $run_dev_script." >&2

--- a/scripts/dev/sync_repos.sh
+++ b/scripts/dev/sync_repos.sh
@@ -22,8 +22,8 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-run_dev_script="$repo_root/src/isaac_ros_common/scripts/run_dev.sh"
-isaac_config_file="$repo_root/src/isaac_ros_common/scripts/.isaac_ros_common-config"
+run_dev_script="$repo_root/ros_ws/src/isaac_ros_common/scripts/run_dev.sh"
+isaac_config_file="$repo_root/ros_ws/src/isaac_ros_common/scripts/.isaac_ros_common-config"
 
 ensure_standard_isaac_config() {
   local config_dir


### PR DESCRIPTION
Closes #23.

## Summary
- move the root Isaac ROS manifest entry to `ros_ws/src/isaac_ros_common`
- update the Stage 2A helper scripts to find `run_dev.sh` and `.isaac_ros_common-config` under that workspace path
- rewrite the top-level and Stage 2A docs so they describe the same checkout layout

## Validation
- `rg -n "src/isaac_ros_common|ros_ws/src/isaac_ros_common" README.md docs scripts isaac_ros.repos -S`
- `bash -n scripts/dev/enter.sh scripts/dev/sync_repos.sh`
- `git diff --check`

## Notes
- The current local workspace still has a legacy `src/isaac_ros_common` checkout, but the tracked repo now consistently points future syncs at `ros_ws/src/isaac_ros_common`.
- I did not run a full sync or container launch here because that depends on host/container tooling availability and would mutate nested checkouts outside the tracked repo.