### PR TITLE
Make Isaac workflow wrappers container-aware

### DIFF
--- a/.isaac_ros_common-config
+++ b/.isaac_ros_common-config
@@ -1,0 +1,1 @@
+CONFIG_IMAGE_KEY=ros2_humble.realsense

--- a/README.md
+++ b/README.md
@@ -40,19 +40,23 @@ Normal iteration uses:
 ./scripts/ops/run_vslam_demo.sh
 ```
 
-`./scripts/dev/bootstrap.sh` syncs all root manifests, ensures the standard
-Isaac ROS config file exists at
+`./scripts/dev/bootstrap.sh` is the host-only setup step. It syncs all root
+manifests on the host, copies the repo-root Isaac ROS config from
+`.isaac_ros_common-config` into
 `ros_ws/src/isaac_ros_common/scripts/.isaac_ros_common-config`, launches the
 upstream Isaac development container, installs GOAT dependency packages, and
 prepares the workspace artifact directories.
 
-`./scripts/dev/build.sh` calls upstream
-`ros_ws/src/isaac_ros_common/scripts/run_dev.sh -d <repo-root>`, builds
-`goat_vesc` first, then rebuilds `goat_vesc_ros`, `goat_teleop`, and
+`./scripts/dev/build.sh` is container-aware. From the host it calls the
+upstream Isaac launcher to run the repo-owned internal build helper inside the
+container; from inside the container it runs that helper directly. The build
+still rebuilds `goat_vesc` first, then `goat_vesc_ros`, `goat_teleop`, and
 `goat_ros_launch` against the shared install space.
 
 `./scripts/ops/run_vslam_demo.sh` is the thin operator-facing launch path. It
-starts the Isaac container, sources the built workspace, and launches
+is also container-aware: from the host it starts or reuses the Isaac container,
+and from inside the container it launches directly without re-running host
+Docker checks. In both cases it sources the built workspace and launches
 `goat_ros_launch/sensors.launch.py`.
 
 ## Layout

--- a/docs/devcontainer_workflow.md
+++ b/docs/devcontainer_workflow.md
@@ -11,11 +11,16 @@ The supported Stage 2A path is:
 Those repo helpers call Isaac ROS tooling directly. They do not rely on Docker
 Compose as the primary container workflow.
 
-`./scripts/dev/bootstrap.sh` and `./scripts/dev/build.sh` invoke the vendored
-upstream `ros_ws/src/isaac_ros_common/scripts/run_dev.sh` directly.
-`./scripts/dev/bootstrap.sh` also ensures the standard Isaac ROS config file
-exists at `ros_ws/src/isaac_ros_common/scripts/.isaac_ros_common-config` with
-`CONFIG_IMAGE_KEY=ros2_humble.realsense`.
+`./scripts/dev/bootstrap.sh` is the host-only entrypoint. It syncs repos on the
+host, then copies the repo-root Isaac config file
+`.isaac_ros_common-config` into
+`ros_ws/src/isaac_ros_common/scripts/.isaac_ros_common-config`.
+
+`./scripts/dev/build.sh` and `./scripts/ops/run_vslam_demo.sh` are
+container-aware. From the host they invoke the vendored upstream Isaac launcher
+under `ros_ws/src/isaac_ros_common/scripts/`; from inside the container they
+run repo-owned internal helper scripts directly instead of re-running host
+Docker setup logic.
 
 ## Current Status
 

--- a/docs/isaac_ros_visual_slam.md
+++ b/docs/isaac_ros_visual_slam.md
@@ -25,16 +25,20 @@ From the repo root:
 ./scripts/ops/run_vslam_demo.sh
 ```
 
-`./scripts/dev/bootstrap.sh` syncs manifest-managed repositories, ensures the
-standard Isaac ROS config file exists at
+`./scripts/dev/bootstrap.sh` is the host-only setup step. It syncs
+manifest-managed repositories on the host, copies the repo-root Isaac config
+from `.isaac_ros_common-config` into
 `ros_ws/src/isaac_ros_common/scripts/.isaac_ros_common-config`, launches the
 Isaac container, installs dependency packages, and prepares the workspace.
 `./scripts/dev/build.sh` then rebuilds the GOAT package set inside that
-container-managed environment.
+container-managed environment. If you run it from inside the container, it
+builds directly without re-triggering host Docker logic.
 
 ## Default Demo Behavior
 
 - `./scripts/ops/run_vslam_demo.sh` is the normal deployment and demo entrypoint.
+- It is container-aware, so running it from inside the Isaac container skips
+  host-side Docker/user/group checks.
 - It launches `goat_ros_launch/sensors.launch.py`, which defaults to the GOAT
   D435 Visual SLAM wrapper from `goat_ros_launch/config/sensors.yaml`.
 - The default GOAT D435 profile is stereo-only:

--- a/scripts/dev/_build_in_container.sh
+++ b/scripts/dev/_build_in_container.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Internal GOAT build helper for use inside the Isaac ROS container only.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+workspace_dir="$repo_root/ros_ws"
+goat_ros_dir="$workspace_dir/src/goat_ros"
+goat_vesc_dir="$repo_root/external/goat_vesc"
+workspace_setup="$workspace_dir/install/setup.bash"
+
+source /opt/ros/humble/setup.bash
+
+if [[ ! -d "$goat_ros_dir" ]]; then
+  echo "GOAT ROS source tree not found at $goat_ros_dir." >&2
+  echo "Run ./scripts/dev/bootstrap.sh first." >&2
+  exit 1
+fi
+
+if [[ ! -d "$goat_vesc_dir" ]]; then
+  echo "GOAT VESC source tree not found at $goat_vesc_dir." >&2
+  echo "Run ./scripts/dev/bootstrap.sh first." >&2
+  exit 1
+fi
+
+mkdir -p "$workspace_dir/build" "$workspace_dir/install" "$workspace_dir/log"
+
+colcon build \
+  --base-paths "$goat_vesc_dir" \
+  --build-base "$workspace_dir/build" \
+  --install-base "$workspace_dir/install" \
+  --log-base "$workspace_dir/log" \
+  --symlink-install \
+  --packages-select goat_vesc \
+  "$@"
+
+if [[ ! -f "$workspace_setup" ]]; then
+  echo "Workspace setup file not found at $workspace_setup after building goat_vesc." >&2
+  exit 1
+fi
+
+source "$workspace_setup"
+
+colcon build \
+  --base-paths "$goat_vesc_dir" "$goat_ros_dir" \
+  --build-base "$workspace_dir/build" \
+  --install-base "$workspace_dir/install" \
+  --log-base "$workspace_dir/log" \
+  --symlink-install \
+  --packages-select goat_vesc_ros goat_teleop goat_ros_launch \
+  "$@"

--- a/scripts/dev/bootstrap.sh
+++ b/scripts/dev/bootstrap.sh
@@ -4,7 +4,7 @@
 # Purpose:
 #   Sync manifest-managed repositories, ensure the Isaac ROS image config is
 #   present, launch the upstream Isaac dev container, install dependencies, and
-#   prepare the workspace artifact directories.
+#   prepare the workspace artifact directories from the host.
 #
 # Inputs:
 #   Root-level `*.repos` manifests plus a host with `vcs` and Docker access.
@@ -22,10 +22,39 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-run_dev_script="$repo_root/ros_ws/src/isaac_ros_common/scripts/run_dev.sh"
-isaac_config_file="$repo_root/ros_ws/src/isaac_ros_common/scripts/.isaac_ros_common-config"
+root_isaac_config_file="$repo_root/.isaac_ros_common-config"
+isaac_repo_dir="$repo_root/ros_ws/src/isaac_ros_common"
+isaac_scripts_dir="$repo_root/ros_ws/src/isaac_ros_common/scripts"
+isaac_config_file="$isaac_scripts_dir/.isaac_ros_common-config"
 goat_ros_dir="$repo_root/ros_ws/src/goat_ros"
 goat_vesc_dir="$repo_root/external/goat_vesc"
+
+is_inside_isaac_container() {
+  [[ -f /.dockerenv || "${ISAAC_ROS_WS:-}" == "/workspaces/isaac_ros-dev" ]]
+}
+
+resolve_isaac_launcher() {
+  local launcher=""
+
+  if [[ -f "$isaac_scripts_dir/run_dev.sh" ]]; then
+    launcher="$isaac_scripts_dir/run_dev.sh"
+  elif [[ -f "$isaac_scripts_dir/enter.sh" ]]; then
+    launcher="$isaac_scripts_dir/enter.sh"
+  fi
+
+  if [[ -z "$launcher" ]]; then
+    echo "Isaac ROS launcher was not found under $isaac_scripts_dir after manifest sync." >&2
+    echo "Check isaac_ros.repos and rerun ./scripts/dev/bootstrap.sh." >&2
+    exit 1
+  fi
+
+  printf '%s\n' "$launcher"
+}
+
+if is_inside_isaac_container; then
+  echo "./scripts/dev/bootstrap.sh must be run on the host, not from inside the Isaac ROS container." >&2
+  exit 1
+fi
 
 if ! command -v vcs >/dev/null 2>&1; then
   echo "vcs was not found on the host." >&2
@@ -62,16 +91,19 @@ if [[ ${#repo_dirs[@]} -gt 0 ]]; then
   vcs pull "${repo_dirs[@]}"
 fi
 
-if [[ ! -f "$run_dev_script" ]]; then
-  echo "Isaac ROS run_dev.sh was not found at $run_dev_script after manifest sync." >&2
+if [[ ! -f "$root_isaac_config_file" ]]; then
+  echo "Repo Isaac ROS config was not found at $root_isaac_config_file." >&2
+  exit 1
+fi
+
+if [[ ! -d "$isaac_repo_dir" ]]; then
+  echo "Isaac ROS source tree not found at $isaac_repo_dir after manifest sync." >&2
   echo "Check isaac_ros.repos and rerun ./scripts/dev/bootstrap.sh." >&2
   exit 1
 fi
 
 mkdir -p "$(dirname "$isaac_config_file")"
-cat > "$isaac_config_file" <<'EOF'
-CONFIG_IMAGE_KEY=ros2_humble.realsense
-EOF
+cp "$root_isaac_config_file" "$isaac_config_file"
 
 if [[ ! -d "$goat_ros_dir" ]]; then
   echo "GOAT ROS source tree not found at $goat_ros_dir after manifest sync." >&2
@@ -84,8 +116,9 @@ if [[ ! -d "$goat_vesc_dir" ]]; then
 fi
 
 export TERM="${TERM:-xterm}"
+launcher="$(resolve_isaac_launcher)"
 
-exec "$run_dev_script" -d "$repo_root" -- -lc '
+exec "$launcher" -d "$repo_root" -- -lc '
 set -e
 
 repo_root="/workspaces/isaac_ros-dev"

--- a/scripts/dev/build.sh
+++ b/scripts/dev/build.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
-# Build GOAT packages inside the Isaac ROS development container.
+# Build GOAT packages in the supported Isaac ROS workflow.
 #
 # Purpose:
-#   Rebuild the fast GOAT C++ library first, then rebuild the GOAT ROS
-#   workspace packages against the same install space.
+#   Dispatch to the container-local GOAT build helper. From the host this
+#   launches or reuses the Isaac ROS container; from inside the container it
+#   builds directly without re-running host Docker checks.
 #
 # Inputs:
 #   Optional extra `colcon build` arguments forwarded to both build phases.
@@ -21,65 +22,41 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-run_dev_script="$repo_root/ros_ws/src/isaac_ros_common/scripts/run_dev.sh"
-goat_ros_dir="$repo_root/ros_ws/src/goat_ros"
-goat_vesc_dir="$repo_root/external/goat_vesc"
+container_script="$repo_root/scripts/dev/_build_in_container.sh"
 
-if [[ ! -f "$run_dev_script" ]]; then
-  echo "Isaac ROS run_dev.sh was not found at $run_dev_script." >&2
-  echo "Run ./scripts/dev/bootstrap.sh first." >&2
+is_inside_isaac_container() {
+  [[ -f /.dockerenv || "${ISAAC_ROS_WS:-}" == "/workspaces/isaac_ros-dev" ]]
+}
+
+resolve_isaac_launcher() {
+  local scripts_dir="$repo_root/ros_ws/src/isaac_ros_common/scripts"
+  local launcher=""
+
+  if [[ -f "$scripts_dir/run_dev.sh" ]]; then
+    launcher="$scripts_dir/run_dev.sh"
+  elif [[ -f "$scripts_dir/enter.sh" ]]; then
+    launcher="$scripts_dir/enter.sh"
+  fi
+
+  if [[ -z "$launcher" ]]; then
+    echo "Isaac ROS launcher was not found under $scripts_dir." >&2
+    echo "Run ./scripts/dev/bootstrap.sh first." >&2
+    exit 1
+  fi
+
+  printf '%s\n' "$launcher"
+}
+
+if [[ ! -f "$container_script" ]]; then
+  echo "Internal build helper not found at $container_script." >&2
   exit 1
 fi
 
-if [[ ! -d "$goat_ros_dir" ]]; then
-  echo "GOAT ROS source tree not found at $goat_ros_dir." >&2
-  echo "Run ./scripts/dev/bootstrap.sh first." >&2
-  exit 1
-fi
-
-if [[ ! -d "$goat_vesc_dir" ]]; then
-  echo "GOAT VESC source tree not found at $goat_vesc_dir." >&2
-  echo "Run ./scripts/dev/bootstrap.sh first." >&2
-  exit 1
+if is_inside_isaac_container; then
+  exec "$container_script" "$@"
 fi
 
 export TERM="${TERM:-xterm}"
+launcher="$(resolve_isaac_launcher)"
 
-exec "$run_dev_script" -d "$repo_root" -- -lc '
-set -e
-
-repo_root="/workspaces/isaac_ros-dev"
-workspace_dir="$repo_root/ros_ws"
-goat_ros_dir="$workspace_dir/src/goat_ros"
-goat_vesc_dir="$repo_root/external/goat_vesc"
-
-source /opt/ros/humble/setup.bash
-
-mkdir -p "$workspace_dir/build" "$workspace_dir/install" "$workspace_dir/log"
-
-colcon build \
-  --base-paths "$goat_vesc_dir" \
-  --build-base "$workspace_dir/build" \
-  --install-base "$workspace_dir/install" \
-  --log-base "$workspace_dir/log" \
-  --symlink-install \
-  --packages-select goat_vesc \
-  "$@"
-
-workspace_setup="$workspace_dir/install/setup.bash"
-if [[ ! -f "$workspace_setup" ]]; then
-  echo "Workspace setup file not found at $workspace_setup after building goat_vesc." >&2
-  exit 1
-fi
-
-source "$workspace_setup"
-
-colcon build \
-  --base-paths "$goat_vesc_dir" "$goat_ros_dir" \
-  --build-base "$workspace_dir/build" \
-  --install-base "$workspace_dir/install" \
-  --log-base "$workspace_dir/log" \
-  --symlink-install \
-  --packages-select goat_vesc_ros goat_teleop goat_ros_launch \
-  "$@"
-' bash "$@"
+exec "$launcher" -d "$repo_root" -- /workspaces/isaac_ros-dev/scripts/dev/_build_in_container.sh "$@"

--- a/scripts/ops/_run_vslam_demo_in_container.sh
+++ b/scripts/ops/_run_vslam_demo_in_container.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Internal GOAT VSLAM demo launcher for use inside the Isaac ROS container only.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+workspace_dir="$repo_root/ros_ws"
+workspace_setup="$workspace_dir/install/setup.bash"
+
+source /opt/ros/humble/setup.bash
+
+if [[ ! -f "$workspace_setup" ]]; then
+  echo "Workspace setup file not found at $workspace_setup." >&2
+  echo "Run ./scripts/dev/build.sh first." >&2
+  exit 1
+fi
+
+source "$workspace_setup"
+cd "$workspace_dir"
+ros2 launch goat_ros_launch sensors.launch.py "$@"

--- a/scripts/ops/run_vslam_demo.sh
+++ b/scripts/ops/run_vslam_demo.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
-# Launch the GOAT Visual SLAM demo inside the Isaac ROS container.
+# Launch the GOAT Visual SLAM demo in the supported Isaac ROS workflow.
 #
 # Purpose:
-#   Source the built GOAT workspace in the Isaac ROS container and start the
-#   default GOAT D435 Visual SLAM launch path.
+#   Dispatch to the container-local demo launcher. From the host this launches
+#   or reuses the Isaac ROS container; from inside the container it launches
+#   directly without re-running host Docker checks.
 #
 # Inputs:
 #   Optional extra `ros2 launch` arguments forwarded to
@@ -21,38 +22,41 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-run_dev_script="$repo_root/ros_ws/src/isaac_ros_common/scripts/run_dev.sh"
-workspace_setup="$repo_root/ros_ws/install/setup.bash"
+container_script="$repo_root/scripts/ops/_run_vslam_demo_in_container.sh"
 
-if [[ ! -f "$run_dev_script" ]]; then
-  echo "Isaac ROS run_dev.sh was not found at $run_dev_script." >&2
-  echo "Run ./scripts/dev/bootstrap.sh first." >&2
+is_inside_isaac_container() {
+  [[ -f /.dockerenv || "${ISAAC_ROS_WS:-}" == "/workspaces/isaac_ros-dev" ]]
+}
+
+resolve_isaac_launcher() {
+  local scripts_dir="$repo_root/ros_ws/src/isaac_ros_common/scripts"
+  local launcher=""
+
+  if [[ -f "$scripts_dir/run_dev.sh" ]]; then
+    launcher="$scripts_dir/run_dev.sh"
+  elif [[ -f "$scripts_dir/enter.sh" ]]; then
+    launcher="$scripts_dir/enter.sh"
+  fi
+
+  if [[ -z "$launcher" ]]; then
+    echo "Isaac ROS launcher was not found under $scripts_dir." >&2
+    echo "Run ./scripts/dev/bootstrap.sh first." >&2
+    exit 1
+  fi
+
+  printf '%s\n' "$launcher"
+}
+
+if [[ ! -f "$container_script" ]]; then
+  echo "Internal VSLAM demo helper not found at $container_script." >&2
   exit 1
 fi
 
-if [[ ! -f "$workspace_setup" ]]; then
-  echo "Workspace setup file not found at $workspace_setup." >&2
-  echo "Run ./scripts/dev/build.sh first." >&2
-  exit 1
+if is_inside_isaac_container; then
+  exec "$container_script" "$@"
 fi
 
 export TERM="${TERM:-xterm}"
+launcher="$(resolve_isaac_launcher)"
 
-exec "$run_dev_script" -d "$repo_root" -- -lc '
-set -e
-
-workspace_dir="/workspaces/isaac_ros-dev/ros_ws"
-workspace_setup="$workspace_dir/install/setup.bash"
-
-source /opt/ros/humble/setup.bash
-
-if [[ ! -f "$workspace_setup" ]]; then
-  echo "Workspace setup file not found at $workspace_setup." >&2
-  echo "Run ./scripts/dev/build.sh first." >&2
-  exit 1
-fi
-
-source "$workspace_setup"
-cd "$workspace_dir"
-ros2 launch goat_ros_launch sensors.launch.py "$@"
-' bash "$@"
+exec "$launcher" -d "$repo_root" -- /workspaces/isaac_ros-dev/scripts/ops/_run_vslam_demo_in_container.sh "$@"


### PR DESCRIPTION
## Summary
- add a repo-root Isaac ROS config and copy it into the vendored Isaac scripts path during bootstrap
- split the build and demo logic into internal container-only helper scripts
- make the public build and demo entrypoints dispatch safely from either the host or the Isaac ROS container
- update the docs to describe the container-aware 3-command workflow and the host-only bootstrap step

## Validation
- `bash -n scripts/dev/bootstrap.sh scripts/dev/build.sh scripts/dev/_build_in_container.sh scripts/ops/run_vslam_demo.sh scripts/ops/_run_vslam_demo_in_container.sh`
- `git diff --check`
- `env ISAAC_ROS_WS=/workspaces/isaac_ros-dev bash scripts/dev/bootstrap.sh`

## Notes
- This is a follow-up to #26.
- I did not run the full Docker build/demo workflow in this environment.
