### PR TITLE
Stabilize upstream Isaac ROS workflow and GOAT overlay tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 !/ros_ws/bags/
 !/ros_ws/bags/README.md
 /ros_ws/src/goat_ros/
+/ros_ws/src/isaac_ros_common/
 /external/goat_vesc/
 /src/isaac_ros_common/
 /log/

--- a/.isaac_ros_common-config
+++ b/.isaac_ros_common-config
@@ -1,1 +1,2 @@
-CONFIG_IMAGE_KEY=ros2_humble.realsense
+CONFIG_IMAGE_KEY=ros2_humble.realsense.goat
+CONFIG_DOCKER_SEARCH_DIRS=(../../../../docker)

--- a/.isaac_ros_dev-dockerargs
+++ b/.isaac_ros_dev-dockerargs
@@ -1,2 +1,2 @@
--e QT_X11_NO_MITSHM=1
--e XAUTHORITY=/home/admin/.Xauthority
+--env=QT_X11_NO_MITSHM=1
+--env=XAUTHORITY=/home/admin/.Xauthority

--- a/.isaac_ros_dev-dockerargs
+++ b/.isaac_ros_dev-dockerargs
@@ -1,0 +1,2 @@
+-e QT_X11_NO_MITSHM=1
+-e XAUTHORITY=/home/admin/.Xauthority

--- a/README.md
+++ b/README.md
@@ -43,22 +43,23 @@ Normal iteration uses:
 `./scripts/dev/bootstrap.sh` is the host-only setup step. It syncs all root
 manifests on the host, copies the repo-root Isaac ROS config from
 `.isaac_ros_common-config` into
-`ros_ws/src/isaac_ros_common/scripts/.isaac_ros_common-config`, then uses
-repo-owned container orchestration to launch or reuse a named Isaac
-development container, install GOAT dependency packages, and prepare the
-workspace artifact directories.
+`ros_ws/src/isaac_ros_common/scripts/.isaac_ros_common-config`, then uses the
+vendored upstream
+`ros_ws/src/isaac_ros_common/scripts/run_dev.sh -d <repo-root>` entrypoint to
+pull, build, or reuse the Isaac development container, install GOAT dependency
+packages, and prepare the workspace artifact directories.
 
-`./scripts/dev/build.sh` is container-aware. From the host it uses repo-owned
-container orchestration to run the internal build helper inside the Isaac
-container; from inside the container it runs that helper directly. The build
-still rebuilds `goat_vesc` first, then `goat_vesc_ros`, `goat_teleop`, and
-`goat_ros_launch` against the shared install space.
+`./scripts/dev/build.sh` is container-aware. From the host it uses upstream
+`run_dev.sh` to run the internal build helper inside the Isaac container; from
+inside the container it runs that helper directly. The build still rebuilds
+`goat_vesc` first, then `goat_vesc_ros`, `goat_teleop`, and `goat_ros_launch`
+against the shared install space.
 
 `./scripts/ops/run_vslam_demo.sh` is the thin operator-facing launch path. It
 is also container-aware: from the host it starts or reuses the Isaac container
-through the same repo-owned orchestration, and from inside the container it
-launches directly without re-running host Docker checks. In both cases it
-sources the built workspace and launches `goat_ros_launch/sensors.launch.py`.
+through the same upstream `run_dev.sh` entrypoint, and from inside the
+container it launches directly. In both cases it sources the built workspace
+and launches `goat_ros_launch/sensors.launch.py`.
 
 ## Layout
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ Normal iteration uses:
 ./scripts/ops/run_vslam_demo.sh
 ```
 
+Open a second shell for ROS operations with:
+
+```bash
+./scripts/dev/enter.sh
+```
+
 `./scripts/dev/bootstrap.sh` is the host-only setup step. It syncs all root
 manifests on the host, copies the repo-root Isaac ROS config from
 `.isaac_ros_common-config` into
@@ -65,9 +71,9 @@ container it launches directly. In both cases it sources the built workspace
 and launches `goat_ros_launch/sensors.launch.py`.
 
 For manual desktop debugging from inside the container on a local Jetson
-session, attach with upstream `run_dev.sh`, launch the demo in one container
-shell, then attach again in a second shell and run `xeyes`, `glxinfo -B`, or
-`rviz2` directly.
+session, launch the demo in one terminal, then use `./scripts/dev/enter.sh` in
+a second terminal and run `ros2 topic list`, `xeyes`, `glxinfo -B`, or `rviz2`
+directly.
 
 ## Layout
 

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ Normal iteration uses:
 manifests on the host, copies the repo-root Isaac ROS config from
 `.isaac_ros_common-config` into
 `ros_ws/src/isaac_ros_common/scripts/.isaac_ros_common-config`, then uses
-repo-owned container orchestration to launch or reuse the Isaac development
-container, install GOAT dependency packages, and prepare the workspace artifact
-directories.
+repo-owned container orchestration to launch or reuse a named Isaac
+development container, install GOAT dependency packages, and prepare the
+workspace artifact directories.
 
 `./scripts/dev/build.sh` is container-aware. From the host it uses repo-owned
 container orchestration to run the internal build helper inside the Isaac

--- a/README.md
+++ b/README.md
@@ -43,21 +43,22 @@ Normal iteration uses:
 `./scripts/dev/bootstrap.sh` is the host-only setup step. It syncs all root
 manifests on the host, copies the repo-root Isaac ROS config from
 `.isaac_ros_common-config` into
-`ros_ws/src/isaac_ros_common/scripts/.isaac_ros_common-config`, launches the
-upstream Isaac development container, installs GOAT dependency packages, and
-prepares the workspace artifact directories.
+`ros_ws/src/isaac_ros_common/scripts/.isaac_ros_common-config`, then uses
+repo-owned container orchestration to launch or reuse the Isaac development
+container, install GOAT dependency packages, and prepare the workspace artifact
+directories.
 
-`./scripts/dev/build.sh` is container-aware. From the host it calls the
-upstream Isaac launcher to run the repo-owned internal build helper inside the
+`./scripts/dev/build.sh` is container-aware. From the host it uses repo-owned
+container orchestration to run the internal build helper inside the Isaac
 container; from inside the container it runs that helper directly. The build
 still rebuilds `goat_vesc` first, then `goat_vesc_ros`, `goat_teleop`, and
 `goat_ros_launch` against the shared install space.
 
 `./scripts/ops/run_vslam_demo.sh` is the thin operator-facing launch path. It
-is also container-aware: from the host it starts or reuses the Isaac container,
-and from inside the container it launches directly without re-running host
-Docker checks. In both cases it sources the built workspace and launches
-`goat_ros_launch/sensors.launch.py`.
+is also container-aware: from the host it starts or reuses the Isaac container
+through the same repo-owned orchestration, and from inside the container it
+launches directly without re-running host Docker checks. In both cases it
+sources the built workspace and launches `goat_ros_launch/sensors.launch.py`.
 
 ## Layout
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,6 @@ directly.
 
 ## Additional Docs
 
-- [Devcontainer workflow](/home/goat/goat/goat_racer/docs/devcontainer_workflow.md)
-- [Version matrix](/home/goat/goat/goat_racer/docs/version_matrix.md)
-- [Isaac ROS Visual SLAM notes](/home/goat/goat/goat_racer/docs/isaac_ros_visual_slam.md)
+- [Devcontainer workflow](docs/devcontainer_workflow.md)
+- [Version matrix](docs/version_matrix.md)
+- [Isaac ROS Visual SLAM notes](docs/isaac_ros_visual_slam.md)

--- a/README.md
+++ b/README.md
@@ -43,12 +43,14 @@ Normal iteration uses:
 `./scripts/dev/bootstrap.sh` is the host-only setup step. It syncs all root
 manifests on the host, copies the repo-root Isaac ROS config from
 `.isaac_ros_common-config` into
-`ros_ws/src/isaac_ros_common/scripts/.isaac_ros_common-config`, then uses the
+`ros_ws/src/isaac_ros_common/scripts/.isaac_ros_common-config` and the
+repo-root upstream Docker args from `.isaac_ros_dev-dockerargs` into
+`ros_ws/src/isaac_ros_common/scripts/.isaac_ros_dev-dockerargs`, then uses the
 vendored upstream
 `ros_ws/src/isaac_ros_common/scripts/run_dev.sh -d <repo-root>` entrypoint to
 pull, build, or reuse the Isaac development container, including the repo-owned
-GOAT image overlay that adds Isaac ROS Visual SLAM, then prepare the workspace
-artifact directories.
+GOAT image overlay that adds Isaac ROS Visual SLAM and basic RViz desktop
+debugging tools, then prepare the workspace artifact directories.
 
 `./scripts/dev/build.sh` is container-aware. From the host it uses upstream
 `run_dev.sh` to run the internal build helper inside the Isaac container; from
@@ -61,6 +63,11 @@ is also container-aware: from the host it starts or reuses the Isaac container
 through the same upstream `run_dev.sh` entrypoint, and from inside the
 container it launches directly. In both cases it sources the built workspace
 and launches `goat_ros_launch/sensors.launch.py`.
+
+For manual desktop debugging from inside the container on a local Jetson
+session, attach with upstream `run_dev.sh`, launch the demo in one container
+shell, then attach again in a second shell and run `xeyes`, `glxinfo -B`, or
+`rviz2` directly.
 
 ## Layout
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ manifests on the host, copies the repo-root Isaac ROS config from
 `ros_ws/src/isaac_ros_common/scripts/.isaac_ros_common-config`, then uses the
 vendored upstream
 `ros_ws/src/isaac_ros_common/scripts/run_dev.sh -d <repo-root>` entrypoint to
-pull, build, or reuse the Isaac development container, install GOAT dependency
-packages, and prepare the workspace artifact directories.
+pull, build, or reuse the Isaac development container, including the repo-owned
+GOAT image overlay that adds Isaac ROS Visual SLAM, then prepare the workspace
+artifact directories.
 
 `./scripts/dev/build.sh` is container-aware. From the host it uses upstream
 `run_dev.sh` to run the internal build helper inside the Isaac container; from

--- a/docker/Dockerfile.goat
+++ b/docker/Dockerfile.goat
@@ -10,4 +10,7 @@ RUN --mount=type=cache,target=/var/cache/apt \
     ros-humble-isaac-ros-visual-slam \
     x11-apps \
     xauth \
+    && echo "/opt/ros/humble/share/isaac_ros_gxf/gxf/lib/serialization" \
+      > /etc/ld.so.conf.d/isaac_ros_gxf_serialization.conf \
+    && ldconfig \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile.goat
+++ b/docker/Dockerfile.goat
@@ -1,0 +1,9 @@
+ARG BASE_IMAGE=ubuntu:22.04
+FROM ${BASE_IMAGE}
+
+SHELL ["/bin/bash", "-c"]
+
+RUN --mount=type=cache,target=/var/cache/apt \
+    apt-get update && apt-get install -y \
+    ros-humble-isaac-ros-visual-slam \
+    && rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile.goat
+++ b/docker/Dockerfile.goat
@@ -5,5 +5,9 @@ SHELL ["/bin/bash", "-c"]
 
 RUN --mount=type=cache,target=/var/cache/apt \
     apt-get update && apt-get install -y \
+    mesa-utils \
+    ros-humble-rviz2 \
     ros-humble-isaac-ros-visual-slam \
+    x11-apps \
+    xauth \
     && rm -rf /var/lib/apt/lists/*

--- a/docs/devcontainer_workflow.md
+++ b/docs/devcontainer_workflow.md
@@ -8,6 +8,10 @@ The supported Stage 2A path is:
 2. `./scripts/dev/build.sh`
 3. `./scripts/ops/run_vslam_demo.sh`
 
+Use `./scripts/dev/enter.sh` from a second terminal when you need an
+interactive shell in the same upstream-managed Isaac environment for ROS
+operations such as topic inspection or RViz.
+
 Those repo helpers delegate container lifecycle management to the vendored
 upstream Isaac ROS `run_dev.sh` entrypoint. They do not rely on Docker Compose
 as the primary container workflow.
@@ -20,10 +24,10 @@ repo-root upstream Docker args file `.isaac_ros_dev-dockerargs` into
 `ros_ws/src/isaac_ros_common/scripts/.isaac_ros_dev-dockerargs` before
 invoking `ros_ws/src/isaac_ros_common/scripts/run_dev.sh -d <repo-root>`.
 
-`./scripts/dev/build.sh` and `./scripts/ops/run_vslam_demo.sh` are
-container-aware. From the host they use that same upstream `run_dev.sh`
-entrypoint to start or reuse the Isaac container; from inside the container
-they run repo-owned internal helper scripts directly instead of re-running host
+`./scripts/dev/build.sh`, `./scripts/dev/enter.sh`, and
+`./scripts/ops/run_vslam_demo.sh` are container-aware. From the host they use
+that same upstream `run_dev.sh` entrypoint to start or reuse the Isaac
+container; from inside the container they run directly without re-running host
 container startup logic.
 
 The synced upstream Docker args file is also the repo-owned place for small

--- a/docs/devcontainer_workflow.md
+++ b/docs/devcontainer_workflow.md
@@ -45,7 +45,7 @@ manual GUI tools like `rviz2`.
 
 If you open the repo in VS Code and choose "Reopen in Container", treat that as
 a secondary workflow. The supported command-line flow still uses
-the three repo-owned scripts above.
+the repo-owned scripts above.
 
 ## Workspace Layout
 

--- a/docs/devcontainer_workflow.md
+++ b/docs/devcontainer_workflow.md
@@ -8,20 +8,21 @@ The supported Stage 2A path is:
 2. `./scripts/dev/build.sh`
 3. `./scripts/ops/run_vslam_demo.sh`
 
-Those repo helpers use repo-owned container orchestration plus vendored Isaac
-image build tooling. They do not rely on Docker Compose as the primary
-container workflow.
+Those repo helpers delegate container lifecycle management to the vendored
+upstream Isaac ROS `run_dev.sh` entrypoint. They do not rely on Docker Compose
+as the primary container workflow.
 
 `./scripts/dev/bootstrap.sh` is the host-only entrypoint. It syncs repos on the
 host, then copies the repo-root Isaac config file
 `.isaac_ros_common-config` into
-`ros_ws/src/isaac_ros_common/scripts/.isaac_ros_common-config`.
+`ros_ws/src/isaac_ros_common/scripts/.isaac_ros_common-config` before invoking
+`ros_ws/src/isaac_ros_common/scripts/run_dev.sh -d <repo-root>`.
 
 `./scripts/dev/build.sh` and `./scripts/ops/run_vslam_demo.sh` are
-container-aware. From the host they use repo-owned container orchestration to
-start or reuse a named Isaac container; from inside the container they run
-repo-owned internal helper scripts directly instead of re-running host Docker
-setup logic.
+container-aware. From the host they use that same upstream `run_dev.sh`
+entrypoint to start or reuse the Isaac container; from inside the container
+they run repo-owned internal helper scripts directly instead of re-running host
+container startup logic.
 
 ## Current Status
 

--- a/docs/devcontainer_workflow.md
+++ b/docs/devcontainer_workflow.md
@@ -8,8 +8,9 @@ The supported Stage 2A path is:
 2. `./scripts/dev/build.sh`
 3. `./scripts/ops/run_vslam_demo.sh`
 
-Those repo helpers call Isaac ROS tooling directly. They do not rely on Docker
-Compose as the primary container workflow.
+Those repo helpers use repo-owned container orchestration plus vendored Isaac
+image build tooling. They do not rely on Docker Compose as the primary
+container workflow.
 
 `./scripts/dev/bootstrap.sh` is the host-only entrypoint. It syncs repos on the
 host, then copies the repo-root Isaac config file
@@ -17,10 +18,10 @@ host, then copies the repo-root Isaac config file
 `ros_ws/src/isaac_ros_common/scripts/.isaac_ros_common-config`.
 
 `./scripts/dev/build.sh` and `./scripts/ops/run_vslam_demo.sh` are
-container-aware. From the host they invoke the vendored upstream Isaac launcher
-under `ros_ws/src/isaac_ros_common/scripts/`; from inside the container they
-run repo-owned internal helper scripts directly instead of re-running host
-Docker setup logic.
+container-aware. From the host they use repo-owned container orchestration to
+start or reuse the Isaac container; from inside the container they run
+repo-owned internal helper scripts directly instead of re-running host Docker
+setup logic.
 
 ## Current Status
 
@@ -33,7 +34,7 @@ Docker setup logic.
 
 If you open the repo in VS Code and choose "Reopen in Container", treat that as
 a secondary workflow. The supported command-line flow still uses
-the three repo-owned scripts above, which delegate to Isaac ROS `run_dev.sh`.
+the three repo-owned scripts above.
 
 ## Workspace Layout
 

--- a/docs/devcontainer_workflow.md
+++ b/docs/devcontainer_workflow.md
@@ -15,14 +15,20 @@ as the primary container workflow.
 `./scripts/dev/bootstrap.sh` is the host-only entrypoint. It syncs repos on the
 host, then copies the repo-root Isaac config file
 `.isaac_ros_common-config` into
-`ros_ws/src/isaac_ros_common/scripts/.isaac_ros_common-config` before invoking
-`ros_ws/src/isaac_ros_common/scripts/run_dev.sh -d <repo-root>`.
+`ros_ws/src/isaac_ros_common/scripts/.isaac_ros_common-config` and the
+repo-root upstream Docker args file `.isaac_ros_dev-dockerargs` into
+`ros_ws/src/isaac_ros_common/scripts/.isaac_ros_dev-dockerargs` before
+invoking `ros_ws/src/isaac_ros_common/scripts/run_dev.sh -d <repo-root>`.
 
 `./scripts/dev/build.sh` and `./scripts/ops/run_vslam_demo.sh` are
 container-aware. From the host they use that same upstream `run_dev.sh`
 entrypoint to start or reuse the Isaac container; from inside the container
 they run repo-owned internal helper scripts directly instead of re-running host
 container startup logic.
+
+The synced upstream Docker args file is also the repo-owned place for small
+container runtime tweaks such as Qt/X11 compatibility environment variables for
+manual GUI tools like `rviz2`.
 
 ## Current Status
 

--- a/docs/devcontainer_workflow.md
+++ b/docs/devcontainer_workflow.md
@@ -19,7 +19,7 @@ host, then copies the repo-root Isaac config file
 
 `./scripts/dev/build.sh` and `./scripts/ops/run_vslam_demo.sh` are
 container-aware. From the host they use repo-owned container orchestration to
-start or reuse the Isaac container; from inside the container they run
+start or reuse a named Isaac container; from inside the container they run
 repo-owned internal helper scripts directly instead of re-running host Docker
 setup logic.
 

--- a/docs/isaac_ros_visual_slam.md
+++ b/docs/isaac_ros_visual_slam.md
@@ -146,7 +146,7 @@ which glxinfo
 
 ## Limits
 
-- The supported operator-facing workflow is intentionally limited to
-  `bootstrap.sh`, `build.sh`, and `run_vslam_demo.sh`.
+- The supported manual workflow is intentionally limited to
+  `bootstrap.sh`, `build.sh`, `enter.sh`, and `run_vslam_demo.sh`.
 - The GOAT D435 wrapper keeps zeroed default static transforms for bench
   testing; replace them with measured transforms before robot evaluation.

--- a/docs/isaac_ros_visual_slam.md
+++ b/docs/isaac_ros_visual_slam.md
@@ -3,9 +3,9 @@
 ## Purpose
 
 This is the supported GOAT bringup guide for Isaac ROS Visual SLAM on a fresh
-Jetson. The goal is to keep the normal workflow on repo-owned container
-orchestration, install Isaac ROS runtime packages as prebuilt debs, and finish
-with the GOAT D435 stereo-only VSLAM demo.
+Jetson. The goal is to keep the normal workflow on upstream Isaac ROS container
+tooling, install Isaac ROS runtime packages as prebuilt debs, and finish with
+the GOAT D435 stereo-only VSLAM demo.
 
 ## Requirements
 
@@ -29,20 +29,20 @@ From the repo root:
 manifest-managed repositories on the host, copies the repo-root Isaac config
 from `.isaac_ros_common-config` into
 `ros_ws/src/isaac_ros_common/scripts/.isaac_ros_common-config`, launches the
-Isaac container through repo-owned container orchestration, installs dependency
-packages, and prepares the workspace. That named container is then reused by
-`./scripts/dev/build.sh` and `./scripts/ops/run_vslam_demo.sh` so the installed
-runtime packages persist across commands. `./scripts/dev/build.sh` then
-rebuilds the GOAT package set inside that container-managed environment. If you
-run it from inside the container, it builds directly without re-triggering host
-Docker logic.
+Isaac container through upstream
+`ros_ws/src/isaac_ros_common/scripts/run_dev.sh -d <repo-root>`, installs
+dependency packages, and prepares the workspace. That container is then reused
+by `./scripts/dev/build.sh` and `./scripts/ops/run_vslam_demo.sh` through the
+same upstream entrypoint. `./scripts/dev/build.sh` then rebuilds the GOAT
+package set inside that environment. If you run it from inside the container,
+it builds directly without re-triggering host container startup logic.
 
 ## Default Demo Behavior
 
 - `./scripts/ops/run_vslam_demo.sh` is the normal deployment and demo entrypoint.
 - It is container-aware, so running it from inside the Isaac container skips
-  host-side Docker/user/group checks, and running it from the host uses the
-  same repo-owned container orchestration as `build.sh`.
+  the upstream container startup path, and running it from the host uses the
+  same upstream `run_dev.sh` entrypoint as `build.sh`.
 - It launches `goat_ros_launch/sensors.launch.py`, which defaults to the GOAT
   D435 Visual SLAM wrapper from `goat_ros_launch/config/sensors.yaml`.
 - The default GOAT D435 profile is stereo-only:

--- a/docs/isaac_ros_visual_slam.md
+++ b/docs/isaac_ros_visual_slam.md
@@ -66,31 +66,42 @@ CLI overrides still work when needed:
 ./scripts/ops/run_vslam_demo.sh sensor_launch_arguments:="enable_imu_fusion:=true"
 ```
 
-## Manual RViz Check
+## ROS Ops Shell
 
-For the first-pass desktop debugging workflow, start from a local Jetson
-desktop terminal with `DISPLAY` already set.
-
-From the repo root on the host:
-
-```bash
-ros_ws/src/isaac_ros_common/scripts/run_dev.sh -d "$PWD"
-```
-
-Inside the first container shell:
+Start the VSLAM demo in one terminal:
 
 ```bash
 ./scripts/ops/run_vslam_demo.sh
 ```
 
-From a second local desktop terminal on the host, attach again:
+From a second terminal on the host, attach to the same upstream-managed Isaac
+environment:
 
 ```bash
-ros_ws/src/isaac_ros_common/scripts/run_dev.sh -d "$PWD"
+./scripts/dev/enter.sh
 ```
 
-Inside the second container shell, do a quick GUI preflight and then start
-RViz manually:
+Inside that second shell, run ROS operations directly:
+
+```bash
+ros2 topic list
+ros2 topic echo /visual_slam/tracking/odometry --once
+rviz2
+```
+
+## Manual RViz Check
+
+For the first-pass desktop debugging workflow, start from a local Jetson
+desktop terminal with `DISPLAY` already set.
+
+From a second local desktop terminal on the host:
+
+```bash
+./scripts/dev/enter.sh
+```
+
+Inside the container shell, do a quick GUI preflight and then start RViz
+manually:
 
 ```bash
 xeyes

--- a/docs/isaac_ros_visual_slam.md
+++ b/docs/isaac_ros_visual_slam.md
@@ -3,9 +3,9 @@
 ## Purpose
 
 This is the supported GOAT bringup guide for Isaac ROS Visual SLAM on a fresh
-Jetson. The goal is to keep the normal workflow on `run_dev.sh`, install Isaac
-ROS runtime packages as prebuilt debs, and finish with the GOAT D435
-stereo-only VSLAM demo.
+Jetson. The goal is to keep the normal workflow on repo-owned container
+orchestration, install Isaac ROS runtime packages as prebuilt debs, and finish
+with the GOAT D435 stereo-only VSLAM demo.
 
 ## Requirements
 
@@ -29,8 +29,9 @@ From the repo root:
 manifest-managed repositories on the host, copies the repo-root Isaac config
 from `.isaac_ros_common-config` into
 `ros_ws/src/isaac_ros_common/scripts/.isaac_ros_common-config`, launches the
-Isaac container, installs dependency packages, and prepares the workspace.
-`./scripts/dev/build.sh` then rebuilds the GOAT package set inside that
+Isaac container through repo-owned container orchestration, installs dependency
+packages, and prepares the workspace. `./scripts/dev/build.sh` then rebuilds
+the GOAT package set inside that
 container-managed environment. If you run it from inside the container, it
 builds directly without re-triggering host Docker logic.
 
@@ -38,7 +39,8 @@ builds directly without re-triggering host Docker logic.
 
 - `./scripts/ops/run_vslam_demo.sh` is the normal deployment and demo entrypoint.
 - It is container-aware, so running it from inside the Isaac container skips
-  host-side Docker/user/group checks.
+  host-side Docker/user/group checks, and running it from the host uses the
+  same repo-owned container orchestration as `build.sh`.
 - It launches `goat_ros_launch/sensors.launch.py`, which defaults to the GOAT
   D435 Visual SLAM wrapper from `goat_ros_launch/config/sensors.yaml`.
 - The default GOAT D435 profile is stereo-only:

--- a/docs/isaac_ros_visual_slam.md
+++ b/docs/isaac_ros_visual_slam.md
@@ -30,10 +30,12 @@ manifest-managed repositories on the host, copies the repo-root Isaac config
 from `.isaac_ros_common-config` into
 `ros_ws/src/isaac_ros_common/scripts/.isaac_ros_common-config`, launches the
 Isaac container through repo-owned container orchestration, installs dependency
-packages, and prepares the workspace. `./scripts/dev/build.sh` then rebuilds
-the GOAT package set inside that
-container-managed environment. If you run it from inside the container, it
-builds directly without re-triggering host Docker logic.
+packages, and prepares the workspace. That named container is then reused by
+`./scripts/dev/build.sh` and `./scripts/ops/run_vslam_demo.sh` so the installed
+runtime packages persist across commands. `./scripts/dev/build.sh` then
+rebuilds the GOAT package set inside that container-managed environment. If you
+run it from inside the container, it builds directly without re-triggering host
+Docker logic.
 
 ## Default Demo Behavior
 

--- a/docs/isaac_ros_visual_slam.md
+++ b/docs/isaac_ros_visual_slam.md
@@ -28,15 +28,18 @@ From the repo root:
 `./scripts/dev/bootstrap.sh` is the host-only setup step. It syncs
 manifest-managed repositories on the host, copies the repo-root Isaac config
 from `.isaac_ros_common-config` into
-`ros_ws/src/isaac_ros_common/scripts/.isaac_ros_common-config`, launches the
+`ros_ws/src/isaac_ros_common/scripts/.isaac_ros_common-config`, syncs the
+repo-root upstream Docker args from `.isaac_ros_dev-dockerargs` into
+`ros_ws/src/isaac_ros_common/scripts/.isaac_ros_dev-dockerargs`, launches the
 Isaac container through upstream
 `ros_ws/src/isaac_ros_common/scripts/run_dev.sh -d <repo-root>`, installs
 dependency packages, and prepares the workspace. The synced Isaac config also
-selects a repo-owned GOAT image layer so `isaac_ros_visual_slam` is available
-in every upstream `run_dev.sh` container rather than only in transient
-bootstrap state. `./scripts/dev/build.sh` then rebuilds the GOAT package set
-inside that environment. If you run it from inside the container, it builds
-directly without re-triggering host container startup logic.
+selects a repo-owned GOAT image layer so `isaac_ros_visual_slam`, `rviz2`,
+`xeyes`, and `glxinfo` are available in every upstream `run_dev.sh` container
+rather than only in transient bootstrap state. `./scripts/dev/build.sh` then
+rebuilds the GOAT package set inside that environment. If you run it from
+inside the container, it builds directly without re-triggering host container
+startup logic.
 
 ## Default Demo Behavior
 
@@ -62,6 +65,41 @@ CLI overrides still work when needed:
 ```bash
 ./scripts/ops/run_vslam_demo.sh sensor_launch_arguments:="enable_imu_fusion:=true"
 ```
+
+## Manual RViz Check
+
+For the first-pass desktop debugging workflow, start from a local Jetson
+desktop terminal with `DISPLAY` already set.
+
+From the repo root on the host:
+
+```bash
+ros_ws/src/isaac_ros_common/scripts/run_dev.sh -d "$PWD"
+```
+
+Inside the first container shell:
+
+```bash
+./scripts/ops/run_vslam_demo.sh
+```
+
+From a second local desktop terminal on the host, attach again:
+
+```bash
+ros_ws/src/isaac_ros_common/scripts/run_dev.sh -d "$PWD"
+```
+
+Inside the second container shell, do a quick GUI preflight and then start
+RViz manually:
+
+```bash
+xeyes
+glxinfo -B
+rviz2
+```
+
+This first pass intentionally uses plain `rviz2` without a GOAT-owned config so
+we can confirm basic container GUI function before tuning displays.
 
 ## Optional Debug Check
 If you want to confirm the preinstalled Isaac packages directly inside the
@@ -90,6 +128,9 @@ Quick spot checks:
 ros2 topic list | grep visual_slam
 ros2 topic echo /visual_slam/tracking/odometry --once
 ros2 pkg prefix isaac_ros_visual_slam
+which rviz2
+which xeyes
+which glxinfo
 ```
 
 ## Limits

--- a/docs/isaac_ros_visual_slam.md
+++ b/docs/isaac_ros_visual_slam.md
@@ -31,11 +31,12 @@ from `.isaac_ros_common-config` into
 `ros_ws/src/isaac_ros_common/scripts/.isaac_ros_common-config`, launches the
 Isaac container through upstream
 `ros_ws/src/isaac_ros_common/scripts/run_dev.sh -d <repo-root>`, installs
-dependency packages, and prepares the workspace. That container is then reused
-by `./scripts/dev/build.sh` and `./scripts/ops/run_vslam_demo.sh` through the
-same upstream entrypoint. `./scripts/dev/build.sh` then rebuilds the GOAT
-package set inside that environment. If you run it from inside the container,
-it builds directly without re-triggering host container startup logic.
+dependency packages, and prepares the workspace. The synced Isaac config also
+selects a repo-owned GOAT image layer so `isaac_ros_visual_slam` is available
+in every upstream `run_dev.sh` container rather than only in transient
+bootstrap state. `./scripts/dev/build.sh` then rebuilds the GOAT package set
+inside that environment. If you run it from inside the container, it builds
+directly without re-triggering host container startup logic.
 
 ## Default Demo Behavior
 
@@ -52,9 +53,9 @@ it builds directly without re-triggering host container startup logic.
   - IMU fusion disabled unless you pass `enable_imu_fusion:=true`
 - `./scripts/dev/build.sh` builds `goat_vesc` first, then `goat_vesc_ros`,
   `goat_teleop`, and `goat_ros_launch`.
-- Isaac ROS runtime packages such as `isaac_ros_visual_slam` are still expected
-  to come from the container image and `rosdep` rather than a source build in
-  this repo.
+- Isaac ROS runtime packages such as `isaac_ros_visual_slam` are expected to
+  come from the upstream-built container image layer rather than a source build
+  in this repo.
 
 CLI overrides still work when needed:
 

--- a/docs/version_matrix.md
+++ b/docs/version_matrix.md
@@ -15,4 +15,5 @@ explicitly so they can be pinned later without guessing.
 | CUDA / TensorRT lane | Inherited from the selected base image and Isaac ROS lane; exact project pin TBD |
 | Default image key | `ros2_humble.realsense.goat` |
 | Default Jetson base image | Upstream Isaac ROS RealSense image plus the repo GOAT overlay selected by `run_dev.sh` |
+| Upstream Docker args file | Repo-owned `.isaac_ros_dev-dockerargs`, synced into vendored Isaac scripts during bootstrap |
 | Placeholder amd64 base image | Same upstream image flow, architecture override not yet the primary lane |

--- a/docs/version_matrix.md
+++ b/docs/version_matrix.md
@@ -13,6 +13,6 @@ explicitly so they can be pinned later without guessing.
 | Isaac ROS apt lane | `release-3` / `release-3.0` |
 | JetPack / L4T lane | JetPack 6.x / L4T r36.x |
 | CUDA / TensorRT lane | Inherited from the selected base image and Isaac ROS lane; exact project pin TBD |
-| Default image key | `ros2_humble.realsense` |
-| Default Jetson base image | Upstream Isaac ROS RealSense image selected by `run_dev.sh` |
+| Default image key | `ros2_humble.realsense.goat` |
+| Default Jetson base image | Upstream Isaac ROS RealSense image plus the repo GOAT overlay selected by `run_dev.sh` |
 | Placeholder amd64 base image | Same upstream image flow, architecture override not yet the primary lane |

--- a/scripts/_lib/isaac_container.sh
+++ b/scripts/_lib/isaac_container.sh
@@ -7,6 +7,7 @@ GOAT_ROOT_ISAAC_CONFIG_FILE="$GOAT_REPO_ROOT/.isaac_ros_common-config"
 GOAT_ISAAC_REPO_DIR="$GOAT_REPO_ROOT/ros_ws/src/isaac_ros_common"
 GOAT_ISAAC_SCRIPTS_DIR="$GOAT_ISAAC_REPO_DIR/scripts"
 GOAT_ISAAC_CONFIG_FILE="$GOAT_ISAAC_SCRIPTS_DIR/.isaac_ros_common-config"
+GOAT_RUN_DEV_SCRIPT="$GOAT_ISAAC_SCRIPTS_DIR/run_dev.sh"
 
 goat_is_inside_isaac_container() {
   [[ -f /.dockerenv || "${ISAAC_ROS_WS:-}" == "$GOAT_CONTAINER_WORKSPACE" ]]
@@ -48,209 +49,17 @@ goat_sync_repo_isaac_config() {
   cp "$GOAT_ROOT_ISAAC_CONFIG_FILE" "$GOAT_ISAAC_CONFIG_FILE"
 }
 
-goat_require_host_docker_access() {
-  local host_user="${USER:-$(id -un)}"
+goat_run_in_isaac_dev() {
+  local container_script="$1"
+  shift
 
-  if [[ $(id -u) -eq 0 ]]; then
-    echo "This workflow cannot be executed with root privileges." >&2
-    echo "Re-run without sudo and configure Docker for non-root access first." >&2
-    exit 1
-  fi
+  goat_sync_repo_isaac_config
 
-  if ! command -v docker >/dev/null 2>&1; then
-    echo "docker was not found on the host." >&2
-    exit 1
-  fi
-
-  if ! id -nG "$host_user" | grep -qw docker; then
-    echo "User |$host_user| is not a member of the 'docker' group." >&2
-    echo "Run 'sudo usermod -aG docker \$USER && newgrp docker', then retry." >&2
-    exit 1
-  fi
-
-  if ! docker ps >/dev/null 2>&1; then
-    echo "Unable to run docker commands on the host." >&2
-    echo "Check the Docker installation and group membership, then retry." >&2
-    exit 1
-  fi
-
-  if ! git lfs version >/dev/null 2>&1; then
-    echo "git-lfs is not installed." >&2
-    echo "Install git-lfs before using the supported GOAT workflow." >&2
-    exit 1
-  fi
-}
-
-goat_load_isaac_config() {
-  if [[ -f "$GOAT_ROOT_ISAAC_CONFIG_FILE" ]]; then
-    goat_safe_source "$GOAT_ROOT_ISAAC_CONFIG_FILE"
-  fi
-
-  if [[ -f "$HOME/.isaac_ros_common-config" ]]; then
-    goat_safe_source "$HOME/.isaac_ros_common-config"
-  fi
-
-  GOAT_PLATFORM="$(uname -m)"
-  GOAT_IMAGE_KEY="${CONFIG_IMAGE_KEY:-ros2_humble}"
-  GOAT_BASE_IMAGE_KEY="$GOAT_PLATFORM"
-  if [[ -n "$GOAT_IMAGE_KEY" ]]; then
-    GOAT_BASE_IMAGE_KEY="$GOAT_PLATFORM.$GOAT_IMAGE_KEY"
-  fi
-
-  GOAT_BASE_NAME="isaac_ros_dev-$GOAT_PLATFORM"
-  if [[ -n "${CONFIG_CONTAINER_NAME_SUFFIX:-}" ]]; then
-    GOAT_BASE_NAME="$GOAT_BASE_NAME-$CONFIG_CONTAINER_NAME_SUFFIX"
-  fi
-  GOAT_CONTAINER_NAME="$GOAT_BASE_NAME-container"
-
-  GOAT_SKIP_IMAGE_BUILD=0
-  if [[ -n "${SKIP_DOCKER_BUILD:-}" || -n "${CONFIG_SKIP_IMAGE_BUILD:-}" ]]; then
-    GOAT_SKIP_IMAGE_BUILD=1
-  fi
-}
-
-goat_remove_exited_container() {
-  if [[ -n "$(docker ps -a --quiet --filter status=exited --filter "name=^/${GOAT_CONTAINER_NAME}$")" ]]; then
-    docker rm "$GOAT_CONTAINER_NAME" >/dev/null
-  fi
-}
-
-goat_container_is_running() {
-  [[ -n "$(docker ps --quiet --filter "name=^/${GOAT_CONTAINER_NAME}$")" ]]
-}
-
-goat_exec_running_container() {
-  docker exec -i -t -u admin \
-    --workdir "$GOAT_CONTAINER_WORKSPACE" \
-    "$GOAT_CONTAINER_NAME" \
-    /bin/bash "$@"
-}
-
-goat_wait_for_running_container() {
-  local attempt=0
-
-  until goat_exec_running_container -lc "true" >/dev/null 2>&1; do
-    attempt=$((attempt + 1))
-    if (( attempt >= 30 )); then
-      echo "Timed out waiting for Isaac container $GOAT_CONTAINER_NAME to become ready." >&2
-      exit 1
-    fi
-    sleep 1
-  done
-}
-
-goat_build_image_if_needed() {
-  local build_image_layers_script="$GOAT_ISAAC_SCRIPTS_DIR/build_image_layers.sh"
-
-  if [[ ! -x "$build_image_layers_script" ]]; then
-    echo "Isaac ROS build_image_layers.sh was not found at $build_image_layers_script." >&2
+  if [[ ! -x "$GOAT_RUN_DEV_SCRIPT" ]]; then
+    echo "Isaac ROS run_dev.sh was not found at $GOAT_RUN_DEV_SCRIPT." >&2
     echo "Run ./scripts/dev/bootstrap.sh first." >&2
     exit 1
   fi
 
-  if (( GOAT_SKIP_IMAGE_BUILD == 0 )); then
-    if ! "$build_image_layers_script" --image_key "$GOAT_BASE_IMAGE_KEY" --image_name "$GOAT_BASE_NAME"; then
-      if [[ -z "$(docker image ls --quiet "$GOAT_BASE_NAME")" ]]; then
-        echo "Building Isaac image $GOAT_BASE_NAME failed and no cached image was found." >&2
-        exit 1
-      fi
-    fi
-  fi
-
-  if [[ -z "$(docker image ls --quiet "$GOAT_BASE_NAME")" ]]; then
-    echo "No built Isaac image was found for $GOAT_BASE_NAME." >&2
-    exit 1
-  fi
-}
-
-goat_append_configured_docker_args() {
-  local docker_args_file="${DOCKER_ARGS_FILE:-.isaac_ros_dev-dockerargs}"
-  local docker_args_filepath=""
-  local arg=""
-
-  if [[ -f "$HOME/$docker_args_file" ]]; then
-    docker_args_filepath="$(realpath "$HOME/$docker_args_file")"
-  elif [[ -f "$GOAT_ISAAC_SCRIPTS_DIR/$docker_args_file" ]]; then
-    docker_args_filepath="$GOAT_ISAAC_SCRIPTS_DIR/$docker_args_file"
-  fi
-
-  if [[ -z "$docker_args_filepath" ]]; then
-    return 0
-  fi
-
-  while IFS= read -r arg; do
-    [[ -n "$arg" ]] || continue
-    GOAT_DOCKER_ARGS+=($(eval "echo $arg | envsubst"))
-  done < "$docker_args_filepath"
-}
-
-goat_build_default_docker_args() {
-  GOAT_DOCKER_ARGS=()
-
-  GOAT_DOCKER_ARGS+=("-v" "/tmp/.X11-unix:/tmp/.X11-unix")
-  GOAT_DOCKER_ARGS+=("-v" "$HOME/.Xauthority:/home/admin/.Xauthority:rw")
-  GOAT_DOCKER_ARGS+=("-e" "DISPLAY")
-  GOAT_DOCKER_ARGS+=("-e" "NVIDIA_VISIBLE_DEVICES=all")
-  GOAT_DOCKER_ARGS+=("-e" "NVIDIA_DRIVER_CAPABILITIES=all")
-  GOAT_DOCKER_ARGS+=("-e" "ROS_DOMAIN_ID")
-  GOAT_DOCKER_ARGS+=("-e" "USER=${USER:-$(id -un)}")
-  GOAT_DOCKER_ARGS+=("-e" "ISAAC_ROS_WS=$GOAT_CONTAINER_WORKSPACE")
-  GOAT_DOCKER_ARGS+=("-e" "HOST_USER_UID=$(id -u)")
-  GOAT_DOCKER_ARGS+=("-e" "HOST_USER_GID=$(id -g)")
-
-  if [[ -n "${SSH_AUTH_SOCK:-}" ]]; then
-    GOAT_DOCKER_ARGS+=("-v" "$SSH_AUTH_SOCK:/ssh-agent")
-    GOAT_DOCKER_ARGS+=("-e" "SSH_AUTH_SOCK=/ssh-agent")
-  fi
-
-  if [[ "$GOAT_PLATFORM" == "aarch64" ]]; then
-    GOAT_DOCKER_ARGS+=("-e" "NVIDIA_VISIBLE_DEVICES=nvidia.com/gpu=all,nvidia.com/pva=all")
-    GOAT_DOCKER_ARGS+=("-v" "/usr/bin/tegrastats:/usr/bin/tegrastats")
-    GOAT_DOCKER_ARGS+=("-v" "/tmp/:/tmp/")
-    GOAT_DOCKER_ARGS+=("-v" "/usr/lib/aarch64-linux-gnu/tegra:/usr/lib/aarch64-linux-gnu/tegra")
-    GOAT_DOCKER_ARGS+=("-v" "/usr/src/jetson_multimedia_api:/usr/src/jetson_multimedia_api")
-    GOAT_DOCKER_ARGS+=("--pid=host")
-    GOAT_DOCKER_ARGS+=("-v" "/usr/share/vpi3:/usr/share/vpi3")
-    GOAT_DOCKER_ARGS+=("-v" "/dev/input:/dev/input")
-
-    if getent group jtop >/dev/null 2>&1; then
-      GOAT_DOCKER_ARGS+=("-v" "/run/jtop.sock:/run/jtop.sock:ro")
-    fi
-  fi
-
-  goat_append_configured_docker_args
-}
-
-goat_exec_in_isaac_container() {
-  local container_script="$1"
-  shift
-
-  goat_require_host_docker_access
-  goat_sync_repo_isaac_config
-  goat_load_isaac_config
-  goat_remove_exited_container
-
-  if ! goat_container_is_running; then
-    goat_build_image_if_needed
-    goat_build_default_docker_args
-
-    docker run -d \
-      --privileged \
-      --network host \
-      --ipc=host \
-      "${GOAT_DOCKER_ARGS[@]}" \
-      -v "$GOAT_REPO_ROOT:$GOAT_CONTAINER_WORKSPACE" \
-      -v /etc/localtime:/etc/localtime:ro \
-      --name "$GOAT_CONTAINER_NAME" \
-      --runtime nvidia \
-      --entrypoint /usr/local/bin/scripts/workspace-entrypoint.sh \
-      --workdir "$GOAT_CONTAINER_WORKSPACE" \
-      "$GOAT_BASE_NAME" \
-      /bin/bash -lc 'trap "exit 0" TERM INT; while true; do sleep 3600; done' >/dev/null
-
-    goat_wait_for_running_container
-  fi
-
-  goat_exec_running_container "$container_script" "$@"
-  exit $?
+  exec "$GOAT_RUN_DEV_SCRIPT" -d "$GOAT_REPO_ROOT" -- "$container_script" "$@"
 }

--- a/scripts/_lib/isaac_container.sh
+++ b/scripts/_lib/isaac_container.sh
@@ -4,9 +4,11 @@
 GOAT_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 GOAT_CONTAINER_WORKSPACE="/workspaces/isaac_ros-dev"
 GOAT_ROOT_ISAAC_CONFIG_FILE="$GOAT_REPO_ROOT/.isaac_ros_common-config"
+GOAT_ROOT_ISAAC_DOCKER_ARGS_FILE="$GOAT_REPO_ROOT/.isaac_ros_dev-dockerargs"
 GOAT_ISAAC_REPO_DIR="$GOAT_REPO_ROOT/ros_ws/src/isaac_ros_common"
 GOAT_ISAAC_SCRIPTS_DIR="$GOAT_ISAAC_REPO_DIR/scripts"
 GOAT_ISAAC_CONFIG_FILE="$GOAT_ISAAC_SCRIPTS_DIR/.isaac_ros_common-config"
+GOAT_ISAAC_DOCKER_ARGS_FILE="$GOAT_ISAAC_SCRIPTS_DIR/.isaac_ros_dev-dockerargs"
 GOAT_RUN_DEV_SCRIPT="$GOAT_ISAAC_SCRIPTS_DIR/run_dev.sh"
 
 goat_is_inside_isaac_container() {
@@ -34,9 +36,14 @@ goat_safe_source() {
   return "$status"
 }
 
-goat_sync_repo_isaac_config() {
+goat_sync_repo_isaac_support_files() {
   if [[ ! -f "$GOAT_ROOT_ISAAC_CONFIG_FILE" ]]; then
     echo "Repo Isaac ROS config was not found at $GOAT_ROOT_ISAAC_CONFIG_FILE." >&2
+    exit 1
+  fi
+
+  if [[ ! -f "$GOAT_ROOT_ISAAC_DOCKER_ARGS_FILE" ]]; then
+    echo "Repo Isaac ROS Docker args file was not found at $GOAT_ROOT_ISAAC_DOCKER_ARGS_FILE." >&2
     exit 1
   fi
 
@@ -47,13 +54,14 @@ goat_sync_repo_isaac_config() {
   fi
 
   cp "$GOAT_ROOT_ISAAC_CONFIG_FILE" "$GOAT_ISAAC_CONFIG_FILE"
+  cp "$GOAT_ROOT_ISAAC_DOCKER_ARGS_FILE" "$GOAT_ISAAC_DOCKER_ARGS_FILE"
 }
 
 goat_run_in_isaac_dev() {
   local container_script="$1"
   shift
 
-  goat_sync_repo_isaac_config
+  goat_sync_repo_isaac_support_files
 
   if [[ ! -x "$GOAT_RUN_DEV_SCRIPT" ]]; then
     echo "Isaac ROS run_dev.sh was not found at $GOAT_RUN_DEV_SCRIPT." >&2

--- a/scripts/_lib/isaac_container.sh
+++ b/scripts/_lib/isaac_container.sh
@@ -71,3 +71,15 @@ goat_run_in_isaac_dev() {
 
   exec "$GOAT_RUN_DEV_SCRIPT" -d "$GOAT_REPO_ROOT" -- "$container_script" "$@"
 }
+
+goat_enter_isaac_dev() {
+  goat_sync_repo_isaac_support_files
+
+  if [[ ! -x "$GOAT_RUN_DEV_SCRIPT" ]]; then
+    echo "Isaac ROS run_dev.sh was not found at $GOAT_RUN_DEV_SCRIPT." >&2
+    echo "Run ./scripts/dev/bootstrap.sh first." >&2
+    exit 1
+  fi
+
+  exec "$GOAT_RUN_DEV_SCRIPT" -d "$GOAT_REPO_ROOT"
+}

--- a/scripts/_lib/isaac_container.sh
+++ b/scripts/_lib/isaac_container.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# Shared Isaac ROS container helpers for the supported GOAT workflow.
+
+GOAT_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GOAT_CONTAINER_WORKSPACE="/workspaces/isaac_ros-dev"
+GOAT_ROOT_ISAAC_CONFIG_FILE="$GOAT_REPO_ROOT/.isaac_ros_common-config"
+GOAT_ISAAC_REPO_DIR="$GOAT_REPO_ROOT/ros_ws/src/isaac_ros_common"
+GOAT_ISAAC_SCRIPTS_DIR="$GOAT_ISAAC_REPO_DIR/scripts"
+GOAT_ISAAC_CONFIG_FILE="$GOAT_ISAAC_SCRIPTS_DIR/.isaac_ros_common-config"
+
+goat_is_inside_isaac_container() {
+  [[ -f /.dockerenv || "${ISAAC_ROS_WS:-}" == "$GOAT_CONTAINER_WORKSPACE" ]]
+}
+
+goat_safe_source() {
+  local had_nounset=0
+
+  case $- in
+    *u*)
+      had_nounset=1
+      set +u
+      ;;
+  esac
+
+  # shellcheck disable=SC1090
+  source "$1"
+  local status=$?
+
+  if (( had_nounset )); then
+    set -u
+  fi
+
+  return "$status"
+}
+
+goat_sync_repo_isaac_config() {
+  if [[ ! -f "$GOAT_ROOT_ISAAC_CONFIG_FILE" ]]; then
+    echo "Repo Isaac ROS config was not found at $GOAT_ROOT_ISAAC_CONFIG_FILE." >&2
+    exit 1
+  fi
+
+  if [[ ! -d "$GOAT_ISAAC_SCRIPTS_DIR" ]]; then
+    echo "Isaac ROS scripts were not found at $GOAT_ISAAC_SCRIPTS_DIR." >&2
+    echo "Run ./scripts/dev/bootstrap.sh first." >&2
+    exit 1
+  fi
+
+  cp "$GOAT_ROOT_ISAAC_CONFIG_FILE" "$GOAT_ISAAC_CONFIG_FILE"
+}
+
+goat_require_host_docker_access() {
+  local host_user="${USER:-$(id -un)}"
+
+  if [[ $(id -u) -eq 0 ]]; then
+    echo "This workflow cannot be executed with root privileges." >&2
+    echo "Re-run without sudo and configure Docker for non-root access first." >&2
+    exit 1
+  fi
+
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "docker was not found on the host." >&2
+    exit 1
+  fi
+
+  if ! id -nG "$host_user" | grep -qw docker; then
+    echo "User |$host_user| is not a member of the 'docker' group." >&2
+    echo "Run 'sudo usermod -aG docker \$USER && newgrp docker', then retry." >&2
+    exit 1
+  fi
+
+  if ! docker ps >/dev/null 2>&1; then
+    echo "Unable to run docker commands on the host." >&2
+    echo "Check the Docker installation and group membership, then retry." >&2
+    exit 1
+  fi
+
+  if ! git lfs version >/dev/null 2>&1; then
+    echo "git-lfs is not installed." >&2
+    echo "Install git-lfs before using the supported GOAT workflow." >&2
+    exit 1
+  fi
+}
+
+goat_load_isaac_config() {
+  if [[ -f "$GOAT_ROOT_ISAAC_CONFIG_FILE" ]]; then
+    goat_safe_source "$GOAT_ROOT_ISAAC_CONFIG_FILE"
+  fi
+
+  if [[ -f "$HOME/.isaac_ros_common-config" ]]; then
+    goat_safe_source "$HOME/.isaac_ros_common-config"
+  fi
+
+  GOAT_PLATFORM="$(uname -m)"
+  GOAT_IMAGE_KEY="${CONFIG_IMAGE_KEY:-ros2_humble}"
+  GOAT_BASE_IMAGE_KEY="$GOAT_PLATFORM"
+  if [[ -n "$GOAT_IMAGE_KEY" ]]; then
+    GOAT_BASE_IMAGE_KEY="$GOAT_PLATFORM.$GOAT_IMAGE_KEY"
+  fi
+
+  GOAT_BASE_NAME="isaac_ros_dev-$GOAT_PLATFORM"
+  if [[ -n "${CONFIG_CONTAINER_NAME_SUFFIX:-}" ]]; then
+    GOAT_BASE_NAME="$GOAT_BASE_NAME-$CONFIG_CONTAINER_NAME_SUFFIX"
+  fi
+  GOAT_CONTAINER_NAME="$GOAT_BASE_NAME-container"
+
+  GOAT_SKIP_IMAGE_BUILD=0
+  if [[ -n "${SKIP_DOCKER_BUILD:-}" || -n "${CONFIG_SKIP_IMAGE_BUILD:-}" ]]; then
+    GOAT_SKIP_IMAGE_BUILD=1
+  fi
+}
+
+goat_remove_exited_container() {
+  if [[ -n "$(docker ps -a --quiet --filter status=exited --filter "name=^/${GOAT_CONTAINER_NAME}$")" ]]; then
+    docker rm "$GOAT_CONTAINER_NAME" >/dev/null
+  fi
+}
+
+goat_container_is_running() {
+  [[ -n "$(docker ps --quiet --filter "name=^/${GOAT_CONTAINER_NAME}$")" ]]
+}
+
+goat_build_image_if_needed() {
+  local build_image_layers_script="$GOAT_ISAAC_SCRIPTS_DIR/build_image_layers.sh"
+
+  if [[ ! -x "$build_image_layers_script" ]]; then
+    echo "Isaac ROS build_image_layers.sh was not found at $build_image_layers_script." >&2
+    echo "Run ./scripts/dev/bootstrap.sh first." >&2
+    exit 1
+  fi
+
+  if (( GOAT_SKIP_IMAGE_BUILD == 0 )); then
+    if ! "$build_image_layers_script" --image_key "$GOAT_BASE_IMAGE_KEY" --image_name "$GOAT_BASE_NAME"; then
+      if [[ -z "$(docker image ls --quiet "$GOAT_BASE_NAME")" ]]; then
+        echo "Building Isaac image $GOAT_BASE_NAME failed and no cached image was found." >&2
+        exit 1
+      fi
+    fi
+  fi
+
+  if [[ -z "$(docker image ls --quiet "$GOAT_BASE_NAME")" ]]; then
+    echo "No built Isaac image was found for $GOAT_BASE_NAME." >&2
+    exit 1
+  fi
+}
+
+goat_append_configured_docker_args() {
+  local docker_args_file="${DOCKER_ARGS_FILE:-.isaac_ros_dev-dockerargs}"
+  local docker_args_filepath=""
+  local arg=""
+
+  if [[ -f "$HOME/$docker_args_file" ]]; then
+    docker_args_filepath="$(realpath "$HOME/$docker_args_file")"
+  elif [[ -f "$GOAT_ISAAC_SCRIPTS_DIR/$docker_args_file" ]]; then
+    docker_args_filepath="$GOAT_ISAAC_SCRIPTS_DIR/$docker_args_file"
+  fi
+
+  if [[ -z "$docker_args_filepath" ]]; then
+    return 0
+  fi
+
+  while IFS= read -r arg; do
+    [[ -n "$arg" ]] || continue
+    GOAT_DOCKER_ARGS+=($(eval "echo $arg | envsubst"))
+  done < "$docker_args_filepath"
+}
+
+goat_build_default_docker_args() {
+  GOAT_DOCKER_ARGS=()
+
+  GOAT_DOCKER_ARGS+=("-v" "/tmp/.X11-unix:/tmp/.X11-unix")
+  GOAT_DOCKER_ARGS+=("-v" "$HOME/.Xauthority:/home/admin/.Xauthority:rw")
+  GOAT_DOCKER_ARGS+=("-e" "DISPLAY")
+  GOAT_DOCKER_ARGS+=("-e" "NVIDIA_VISIBLE_DEVICES=all")
+  GOAT_DOCKER_ARGS+=("-e" "NVIDIA_DRIVER_CAPABILITIES=all")
+  GOAT_DOCKER_ARGS+=("-e" "ROS_DOMAIN_ID")
+  GOAT_DOCKER_ARGS+=("-e" "USER=${USER:-$(id -un)}")
+  GOAT_DOCKER_ARGS+=("-e" "ISAAC_ROS_WS=$GOAT_CONTAINER_WORKSPACE")
+  GOAT_DOCKER_ARGS+=("-e" "HOST_USER_UID=$(id -u)")
+  GOAT_DOCKER_ARGS+=("-e" "HOST_USER_GID=$(id -g)")
+
+  if [[ -n "${SSH_AUTH_SOCK:-}" ]]; then
+    GOAT_DOCKER_ARGS+=("-v" "$SSH_AUTH_SOCK:/ssh-agent")
+    GOAT_DOCKER_ARGS+=("-e" "SSH_AUTH_SOCK=/ssh-agent")
+  fi
+
+  if [[ "$GOAT_PLATFORM" == "aarch64" ]]; then
+    GOAT_DOCKER_ARGS+=("-e" "NVIDIA_VISIBLE_DEVICES=nvidia.com/gpu=all,nvidia.com/pva=all")
+    GOAT_DOCKER_ARGS+=("-v" "/usr/bin/tegrastats:/usr/bin/tegrastats")
+    GOAT_DOCKER_ARGS+=("-v" "/tmp/:/tmp/")
+    GOAT_DOCKER_ARGS+=("-v" "/usr/lib/aarch64-linux-gnu/tegra:/usr/lib/aarch64-linux-gnu/tegra")
+    GOAT_DOCKER_ARGS+=("-v" "/usr/src/jetson_multimedia_api:/usr/src/jetson_multimedia_api")
+    GOAT_DOCKER_ARGS+=("--pid=host")
+    GOAT_DOCKER_ARGS+=("-v" "/usr/share/vpi3:/usr/share/vpi3")
+    GOAT_DOCKER_ARGS+=("-v" "/dev/input:/dev/input")
+
+    if getent group jtop >/dev/null 2>&1; then
+      GOAT_DOCKER_ARGS+=("-v" "/run/jtop.sock:/run/jtop.sock:ro")
+    fi
+  fi
+
+  goat_append_configured_docker_args
+}
+
+goat_exec_in_isaac_container() {
+  local container_script="$1"
+  shift
+
+  goat_require_host_docker_access
+  goat_sync_repo_isaac_config
+  goat_load_isaac_config
+  goat_remove_exited_container
+
+  if goat_container_is_running; then
+    exec docker exec -i -t -u admin \
+      --workdir "$GOAT_CONTAINER_WORKSPACE" \
+      "$GOAT_CONTAINER_NAME" \
+      /bin/bash "$container_script" "$@"
+  fi
+
+  goat_build_image_if_needed
+  goat_build_default_docker_args
+
+  exec docker run -it --rm \
+    --privileged \
+    --network host \
+    --ipc=host \
+    "${GOAT_DOCKER_ARGS[@]}" \
+    -v "$GOAT_REPO_ROOT:$GOAT_CONTAINER_WORKSPACE" \
+    -v /etc/localtime:/etc/localtime:ro \
+    --name "$GOAT_CONTAINER_NAME" \
+    --runtime nvidia \
+    --entrypoint /usr/local/bin/scripts/workspace-entrypoint.sh \
+    --workdir "$GOAT_CONTAINER_WORKSPACE" \
+    "$GOAT_BASE_NAME" \
+    /bin/bash "$container_script" "$@"
+}

--- a/scripts/_lib/isaac_container.sh
+++ b/scripts/_lib/isaac_container.sh
@@ -251,5 +251,6 @@ goat_exec_in_isaac_container() {
     goat_wait_for_running_container
   fi
 
-  exec goat_exec_running_container "$container_script" "$@"
+  goat_exec_running_container "$container_script" "$@"
+  exit $?
 }

--- a/scripts/_lib/isaac_container.sh
+++ b/scripts/_lib/isaac_container.sh
@@ -57,29 +57,27 @@ goat_sync_repo_isaac_support_files() {
   cp "$GOAT_ROOT_ISAAC_DOCKER_ARGS_FILE" "$GOAT_ISAAC_DOCKER_ARGS_FILE"
 }
 
-goat_run_in_isaac_dev() {
-  local container_script="$1"
-  shift
-
-  goat_sync_repo_isaac_support_files
-
+goat_require_run_dev_script() {
   if [[ ! -x "$GOAT_RUN_DEV_SCRIPT" ]]; then
     echo "Isaac ROS run_dev.sh was not found at $GOAT_RUN_DEV_SCRIPT." >&2
     echo "Run ./scripts/dev/bootstrap.sh first." >&2
     exit 1
   fi
+}
+
+goat_run_in_isaac_dev() {
+  local container_script="$1"
+  shift
+
+  goat_sync_repo_isaac_support_files
+  goat_require_run_dev_script
 
   exec "$GOAT_RUN_DEV_SCRIPT" -d "$GOAT_REPO_ROOT" -- "$container_script" "$@"
 }
 
 goat_enter_isaac_dev() {
   goat_sync_repo_isaac_support_files
-
-  if [[ ! -x "$GOAT_RUN_DEV_SCRIPT" ]]; then
-    echo "Isaac ROS run_dev.sh was not found at $GOAT_RUN_DEV_SCRIPT." >&2
-    echo "Run ./scripts/dev/bootstrap.sh first." >&2
-    exit 1
-  fi
+  goat_require_run_dev_script
 
   exec "$GOAT_RUN_DEV_SCRIPT" -d "$GOAT_REPO_ROOT"
 }

--- a/scripts/_lib/isaac_container.sh
+++ b/scripts/_lib/isaac_container.sh
@@ -119,6 +119,26 @@ goat_container_is_running() {
   [[ -n "$(docker ps --quiet --filter "name=^/${GOAT_CONTAINER_NAME}$")" ]]
 }
 
+goat_exec_running_container() {
+  docker exec -i -t -u admin \
+    --workdir "$GOAT_CONTAINER_WORKSPACE" \
+    "$GOAT_CONTAINER_NAME" \
+    /bin/bash "$@"
+}
+
+goat_wait_for_running_container() {
+  local attempt=0
+
+  until goat_exec_running_container -lc "true" >/dev/null 2>&1; do
+    attempt=$((attempt + 1))
+    if (( attempt >= 30 )); then
+      echo "Timed out waiting for Isaac container $GOAT_CONTAINER_NAME to become ready." >&2
+      exit 1
+    fi
+    sleep 1
+  done
+}
+
 goat_build_image_if_needed() {
   local build_image_layers_script="$GOAT_ISAAC_SCRIPTS_DIR/build_image_layers.sh"
 
@@ -210,27 +230,26 @@ goat_exec_in_isaac_container() {
   goat_load_isaac_config
   goat_remove_exited_container
 
-  if goat_container_is_running; then
-    exec docker exec -i -t -u admin \
+  if ! goat_container_is_running; then
+    goat_build_image_if_needed
+    goat_build_default_docker_args
+
+    docker run -d \
+      --privileged \
+      --network host \
+      --ipc=host \
+      "${GOAT_DOCKER_ARGS[@]}" \
+      -v "$GOAT_REPO_ROOT:$GOAT_CONTAINER_WORKSPACE" \
+      -v /etc/localtime:/etc/localtime:ro \
+      --name "$GOAT_CONTAINER_NAME" \
+      --runtime nvidia \
+      --entrypoint /usr/local/bin/scripts/workspace-entrypoint.sh \
       --workdir "$GOAT_CONTAINER_WORKSPACE" \
-      "$GOAT_CONTAINER_NAME" \
-      /bin/bash "$container_script" "$@"
+      "$GOAT_BASE_NAME" \
+      /bin/bash -lc 'trap "exit 0" TERM INT; while true; do sleep 3600; done' >/dev/null
+
+    goat_wait_for_running_container
   fi
 
-  goat_build_image_if_needed
-  goat_build_default_docker_args
-
-  exec docker run -it --rm \
-    --privileged \
-    --network host \
-    --ipc=host \
-    "${GOAT_DOCKER_ARGS[@]}" \
-    -v "$GOAT_REPO_ROOT:$GOAT_CONTAINER_WORKSPACE" \
-    -v /etc/localtime:/etc/localtime:ro \
-    --name "$GOAT_CONTAINER_NAME" \
-    --runtime nvidia \
-    --entrypoint /usr/local/bin/scripts/workspace-entrypoint.sh \
-    --workdir "$GOAT_CONTAINER_WORKSPACE" \
-    "$GOAT_BASE_NAME" \
-    /bin/bash "$container_script" "$@"
+  exec goat_exec_running_container "$container_script" "$@"
 }

--- a/scripts/dev/_bootstrap_in_container.sh
+++ b/scripts/dev/_bootstrap_in_container.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Internal GOAT bootstrap helper for use inside the Isaac ROS container only.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$repo_root/scripts/_lib/isaac_container.sh"
+
+workspace_dir="$repo_root/ros_ws"
+goat_ros_dir="$workspace_dir/src/goat_ros"
+goat_vesc_dir="$repo_root/external/goat_vesc"
+
+goat_safe_source /opt/ros/humble/setup.bash
+
+if [[ ! -d "$goat_ros_dir" ]]; then
+  echo "GOAT ROS source tree not found at $goat_ros_dir after bootstrap sync." >&2
+  exit 1
+fi
+
+if [[ ! -d "$goat_vesc_dir" ]]; then
+  echo "GOAT VESC source tree not found at $goat_vesc_dir after bootstrap sync." >&2
+  exit 1
+fi
+
+rosdep update
+rosdep install --from-paths "$goat_vesc_dir" "$goat_ros_dir" --ignore-src --rosdistro humble -r -y
+
+mkdir -p "$workspace_dir/build" "$workspace_dir/install" "$workspace_dir/log"

--- a/scripts/dev/_build_in_container.sh
+++ b/scripts/dev/_build_in_container.sh
@@ -3,12 +3,14 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$repo_root/scripts/_lib/isaac_container.sh"
+
 workspace_dir="$repo_root/ros_ws"
 goat_ros_dir="$workspace_dir/src/goat_ros"
 goat_vesc_dir="$repo_root/external/goat_vesc"
 workspace_setup="$workspace_dir/install/setup.bash"
 
-source /opt/ros/humble/setup.bash
+goat_safe_source /opt/ros/humble/setup.bash
 
 if [[ ! -d "$goat_ros_dir" ]]; then
   echo "GOAT ROS source tree not found at $goat_ros_dir." >&2
@@ -38,7 +40,7 @@ if [[ ! -f "$workspace_setup" ]]; then
   exit 1
 fi
 
-source "$workspace_setup"
+goat_safe_source "$workspace_setup"
 
 colcon build \
   --base-paths "$goat_vesc_dir" "$goat_ros_dir" \

--- a/scripts/dev/_build_in_container.sh
+++ b/scripts/dev/_build_in_container.sh
@@ -26,11 +26,12 @@ fi
 
 mkdir -p "$workspace_dir/build" "$workspace_dir/install" "$workspace_dir/log"
 
-colcon build \
+colcon \
+  --log-base "$workspace_dir/log" \
+  build \
   --base-paths "$goat_vesc_dir" \
   --build-base "$workspace_dir/build" \
   --install-base "$workspace_dir/install" \
-  --log-base "$workspace_dir/log" \
   --symlink-install \
   --packages-select goat_vesc \
   "$@"
@@ -42,11 +43,12 @@ fi
 
 goat_safe_source "$workspace_setup"
 
-colcon build \
+colcon \
+  --log-base "$workspace_dir/log" \
+  build \
   --base-paths "$goat_vesc_dir" "$goat_ros_dir" \
   --build-base "$workspace_dir/build" \
   --install-base "$workspace_dir/install" \
-  --log-base "$workspace_dir/log" \
   --symlink-install \
   --packages-select goat_vesc_ros goat_teleop goat_ros_launch \
   "$@"

--- a/scripts/dev/bootstrap.sh
+++ b/scripts/dev/bootstrap.sh
@@ -22,36 +22,16 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$repo_root/scripts/_lib/isaac_container.sh"
+
 root_isaac_config_file="$repo_root/.isaac_ros_common-config"
 isaac_repo_dir="$repo_root/ros_ws/src/isaac_ros_common"
-isaac_scripts_dir="$repo_root/ros_ws/src/isaac_ros_common/scripts"
-isaac_config_file="$isaac_scripts_dir/.isaac_ros_common-config"
 goat_ros_dir="$repo_root/ros_ws/src/goat_ros"
 goat_vesc_dir="$repo_root/external/goat_vesc"
+container_script="$repo_root/scripts/dev/_bootstrap_in_container.sh"
+container_script_in_workspace="$GOAT_CONTAINER_WORKSPACE/scripts/dev/_bootstrap_in_container.sh"
 
-is_inside_isaac_container() {
-  [[ -f /.dockerenv || "${ISAAC_ROS_WS:-}" == "/workspaces/isaac_ros-dev" ]]
-}
-
-resolve_isaac_launcher() {
-  local launcher=""
-
-  if [[ -f "$isaac_scripts_dir/run_dev.sh" ]]; then
-    launcher="$isaac_scripts_dir/run_dev.sh"
-  elif [[ -f "$isaac_scripts_dir/enter.sh" ]]; then
-    launcher="$isaac_scripts_dir/enter.sh"
-  fi
-
-  if [[ -z "$launcher" ]]; then
-    echo "Isaac ROS launcher was not found under $isaac_scripts_dir after manifest sync." >&2
-    echo "Check isaac_ros.repos and rerun ./scripts/dev/bootstrap.sh." >&2
-    exit 1
-  fi
-
-  printf '%s\n' "$launcher"
-}
-
-if is_inside_isaac_container; then
+if goat_is_inside_isaac_container; then
   echo "./scripts/dev/bootstrap.sh must be run on the host, not from inside the Isaac ROS container." >&2
   exit 1
 fi
@@ -102,8 +82,10 @@ if [[ ! -d "$isaac_repo_dir" ]]; then
   exit 1
 fi
 
-mkdir -p "$(dirname "$isaac_config_file")"
-cp "$root_isaac_config_file" "$isaac_config_file"
+if [[ ! -f "$container_script" ]]; then
+  echo "Internal bootstrap helper not found at $container_script." >&2
+  exit 1
+fi
 
 if [[ ! -d "$goat_ros_dir" ]]; then
   echo "GOAT ROS source tree not found at $goat_ros_dir after manifest sync." >&2
@@ -115,31 +97,7 @@ if [[ ! -d "$goat_vesc_dir" ]]; then
   exit 1
 fi
 
+goat_sync_repo_isaac_config
+
 export TERM="${TERM:-xterm}"
-launcher="$(resolve_isaac_launcher)"
-
-exec "$launcher" -d "$repo_root" -- -lc '
-set -e
-
-repo_root="/workspaces/isaac_ros-dev"
-workspace_dir="$repo_root/ros_ws"
-goat_ros_dir="$workspace_dir/src/goat_ros"
-goat_vesc_dir="$repo_root/external/goat_vesc"
-
-source /opt/ros/humble/setup.bash
-
-if [[ ! -d "$goat_ros_dir" ]]; then
-  echo "GOAT ROS source tree not found at $goat_ros_dir after bootstrap sync." >&2
-  exit 1
-fi
-
-if [[ ! -d "$goat_vesc_dir" ]]; then
-  echo "GOAT VESC source tree not found at $goat_vesc_dir after bootstrap sync." >&2
-  exit 1
-fi
-
-rosdep update
-rosdep install --from-paths "$goat_vesc_dir" "$goat_ros_dir" --ignore-src --rosdistro humble -r -y
-
-mkdir -p "$workspace_dir/build" "$workspace_dir/install" "$workspace_dir/log"
-' bash
+goat_exec_in_isaac_container "$container_script_in_workspace"

--- a/scripts/dev/bootstrap.sh
+++ b/scripts/dev/bootstrap.sh
@@ -3,8 +3,9 @@
 #
 # Purpose:
 #   Sync manifest-managed repositories, ensure the Isaac ROS image config is
-#   present, delegate container lifecycle management to upstream Isaac ROS
-#   tooling, install dependencies, and prepare the workspace artifact
+#   present, sync repo-owned Isaac support files into the vendored upstream
+#   scripts directory, delegate container lifecycle management to upstream
+#   Isaac ROS tooling, install dependencies, and prepare the workspace artifact
 #   directories from the host.
 #
 # Inputs:
@@ -26,6 +27,7 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 source "$repo_root/scripts/_lib/isaac_container.sh"
 
 root_isaac_config_file="$repo_root/.isaac_ros_common-config"
+root_isaac_docker_args_file="$repo_root/.isaac_ros_dev-dockerargs"
 isaac_repo_dir="$repo_root/ros_ws/src/isaac_ros_common"
 run_dev_script="$isaac_repo_dir/scripts/run_dev.sh"
 goat_ros_dir="$repo_root/ros_ws/src/goat_ros"
@@ -78,6 +80,11 @@ if [[ ! -f "$root_isaac_config_file" ]]; then
   exit 1
 fi
 
+if [[ ! -f "$root_isaac_docker_args_file" ]]; then
+  echo "Repo Isaac ROS Docker args file was not found at $root_isaac_docker_args_file." >&2
+  exit 1
+fi
+
 if [[ ! -d "$isaac_repo_dir" ]]; then
   echo "Isaac ROS source tree not found at $isaac_repo_dir after manifest sync." >&2
   echo "Check isaac_ros.repos and rerun ./scripts/dev/bootstrap.sh." >&2
@@ -105,7 +112,7 @@ if [[ ! -d "$goat_vesc_dir" ]]; then
   exit 1
 fi
 
-goat_sync_repo_isaac_config
+goat_sync_repo_isaac_support_files
 
 export TERM="${TERM:-xterm}"
 goat_run_in_isaac_dev "$container_script_in_workspace"

--- a/scripts/dev/bootstrap.sh
+++ b/scripts/dev/bootstrap.sh
@@ -3,8 +3,9 @@
 #
 # Purpose:
 #   Sync manifest-managed repositories, ensure the Isaac ROS image config is
-#   present, launch the upstream Isaac dev container, install dependencies, and
-#   prepare the workspace artifact directories from the host.
+#   present, delegate container lifecycle management to upstream Isaac ROS
+#   tooling, install dependencies, and prepare the workspace artifact
+#   directories from the host.
 #
 # Inputs:
 #   Root-level `*.repos` manifests plus a host with `vcs` and Docker access.
@@ -26,6 +27,7 @@ source "$repo_root/scripts/_lib/isaac_container.sh"
 
 root_isaac_config_file="$repo_root/.isaac_ros_common-config"
 isaac_repo_dir="$repo_root/ros_ws/src/isaac_ros_common"
+run_dev_script="$isaac_repo_dir/scripts/run_dev.sh"
 goat_ros_dir="$repo_root/ros_ws/src/goat_ros"
 goat_vesc_dir="$repo_root/external/goat_vesc"
 container_script="$repo_root/scripts/dev/_bootstrap_in_container.sh"
@@ -82,6 +84,12 @@ if [[ ! -d "$isaac_repo_dir" ]]; then
   exit 1
 fi
 
+if [[ ! -x "$run_dev_script" ]]; then
+  echo "Isaac ROS run_dev.sh was not found at $run_dev_script after manifest sync." >&2
+  echo "Check isaac_ros.repos and rerun ./scripts/dev/bootstrap.sh." >&2
+  exit 1
+fi
+
 if [[ ! -f "$container_script" ]]; then
   echo "Internal bootstrap helper not found at $container_script." >&2
   exit 1
@@ -100,4 +108,4 @@ fi
 goat_sync_repo_isaac_config
 
 export TERM="${TERM:-xterm}"
-goat_exec_in_isaac_container "$container_script_in_workspace"
+goat_run_in_isaac_dev "$container_script_in_workspace"

--- a/scripts/dev/build.sh
+++ b/scripts/dev/build.sh
@@ -22,41 +22,33 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$repo_root/scripts/_lib/isaac_container.sh"
+
 container_script="$repo_root/scripts/dev/_build_in_container.sh"
-
-is_inside_isaac_container() {
-  [[ -f /.dockerenv || "${ISAAC_ROS_WS:-}" == "/workspaces/isaac_ros-dev" ]]
-}
-
-resolve_isaac_launcher() {
-  local scripts_dir="$repo_root/ros_ws/src/isaac_ros_common/scripts"
-  local launcher=""
-
-  if [[ -f "$scripts_dir/run_dev.sh" ]]; then
-    launcher="$scripts_dir/run_dev.sh"
-  elif [[ -f "$scripts_dir/enter.sh" ]]; then
-    launcher="$scripts_dir/enter.sh"
-  fi
-
-  if [[ -z "$launcher" ]]; then
-    echo "Isaac ROS launcher was not found under $scripts_dir." >&2
-    echo "Run ./scripts/dev/bootstrap.sh first." >&2
-    exit 1
-  fi
-
-  printf '%s\n' "$launcher"
-}
+container_script_in_workspace="$GOAT_CONTAINER_WORKSPACE/scripts/dev/_build_in_container.sh"
+goat_ros_dir="$repo_root/ros_ws/src/goat_ros"
+goat_vesc_dir="$repo_root/external/goat_vesc"
 
 if [[ ! -f "$container_script" ]]; then
   echo "Internal build helper not found at $container_script." >&2
   exit 1
 fi
 
-if is_inside_isaac_container; then
+if goat_is_inside_isaac_container; then
   exec "$container_script" "$@"
 fi
 
-export TERM="${TERM:-xterm}"
-launcher="$(resolve_isaac_launcher)"
+if [[ ! -d "$goat_ros_dir" ]]; then
+  echo "GOAT ROS source tree not found at $goat_ros_dir." >&2
+  echo "Run ./scripts/dev/bootstrap.sh first." >&2
+  exit 1
+fi
 
-exec "$launcher" -d "$repo_root" -- /workspaces/isaac_ros-dev/scripts/dev/_build_in_container.sh "$@"
+if [[ ! -d "$goat_vesc_dir" ]]; then
+  echo "GOAT VESC source tree not found at $goat_vesc_dir." >&2
+  echo "Run ./scripts/dev/bootstrap.sh first." >&2
+  exit 1
+fi
+
+export TERM="${TERM:-xterm}"
+goat_exec_in_isaac_container "$container_script_in_workspace" "$@"

--- a/scripts/dev/build.sh
+++ b/scripts/dev/build.sh
@@ -3,8 +3,8 @@
 #
 # Purpose:
 #   Dispatch to the container-local GOAT build helper. From the host this
-#   launches or reuses the Isaac ROS container; from inside the container it
-#   builds directly without re-running host Docker checks.
+#   launches or reuses the Isaac ROS dev container through upstream
+#   `run_dev.sh`; from inside the container it builds directly.
 #
 # Inputs:
 #   Optional extra `colcon build` arguments forwarded to both build phases.
@@ -51,4 +51,4 @@ if [[ ! -d "$goat_vesc_dir" ]]; then
 fi
 
 export TERM="${TERM:-xterm}"
-goat_exec_in_isaac_container "$container_script_in_workspace" "$@"
+goat_run_in_isaac_dev "$container_script_in_workspace" "$@"

--- a/scripts/dev/enter.sh
+++ b/scripts/dev/enter.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Open an interactive shell in the Isaac ROS development container.
+#
+# Purpose:
+#   Attach to the upstream-managed Isaac ROS development container for manual
+#   ROS operations such as topic inspection, RViz, and debug commands.
+#
+# Inputs:
+#   A bootstrapped checkout with `ros_ws/src/isaac_ros_common/scripts/run_dev.sh`.
+#
+# Outputs:
+#   Opens an interactive shell in the Isaac ROS development environment.
+#
+# Usage:
+#   ./scripts/dev/enter.sh
+#
+# Notes:
+#   This command is shell-only; it does not forward one-off command arguments.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$repo_root/scripts/_lib/isaac_container.sh"
+
+if [[ $# -gt 0 ]]; then
+  echo "./scripts/dev/enter.sh does not accept command arguments." >&2
+  echo "Open a shell, then run ROS operations such as 'ros2 topic list' inside it." >&2
+  exit 1
+fi
+
+if goat_is_inside_isaac_container; then
+  exec bash -i
+fi
+
+export TERM="${TERM:-xterm}"
+goat_enter_isaac_dev

--- a/scripts/ops/_run_vslam_demo_in_container.sh
+++ b/scripts/ops/_run_vslam_demo_in_container.sh
@@ -3,10 +3,12 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$repo_root/scripts/_lib/isaac_container.sh"
+
 workspace_dir="$repo_root/ros_ws"
 workspace_setup="$workspace_dir/install/setup.bash"
 
-source /opt/ros/humble/setup.bash
+goat_safe_source /opt/ros/humble/setup.bash
 
 if [[ ! -f "$workspace_setup" ]]; then
   echo "Workspace setup file not found at $workspace_setup." >&2
@@ -14,6 +16,6 @@ if [[ ! -f "$workspace_setup" ]]; then
   exit 1
 fi
 
-source "$workspace_setup"
+goat_safe_source "$workspace_setup"
 cd "$workspace_dir"
 ros2 launch goat_ros_launch sensors.launch.py "$@"

--- a/scripts/ops/run_vslam_demo.sh
+++ b/scripts/ops/run_vslam_demo.sh
@@ -22,41 +22,26 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$repo_root/scripts/_lib/isaac_container.sh"
+
 container_script="$repo_root/scripts/ops/_run_vslam_demo_in_container.sh"
-
-is_inside_isaac_container() {
-  [[ -f /.dockerenv || "${ISAAC_ROS_WS:-}" == "/workspaces/isaac_ros-dev" ]]
-}
-
-resolve_isaac_launcher() {
-  local scripts_dir="$repo_root/ros_ws/src/isaac_ros_common/scripts"
-  local launcher=""
-
-  if [[ -f "$scripts_dir/run_dev.sh" ]]; then
-    launcher="$scripts_dir/run_dev.sh"
-  elif [[ -f "$scripts_dir/enter.sh" ]]; then
-    launcher="$scripts_dir/enter.sh"
-  fi
-
-  if [[ -z "$launcher" ]]; then
-    echo "Isaac ROS launcher was not found under $scripts_dir." >&2
-    echo "Run ./scripts/dev/bootstrap.sh first." >&2
-    exit 1
-  fi
-
-  printf '%s\n' "$launcher"
-}
+container_script_in_workspace="$GOAT_CONTAINER_WORKSPACE/scripts/ops/_run_vslam_demo_in_container.sh"
+workspace_setup="$repo_root/ros_ws/install/setup.bash"
 
 if [[ ! -f "$container_script" ]]; then
   echo "Internal VSLAM demo helper not found at $container_script." >&2
   exit 1
 fi
 
-if is_inside_isaac_container; then
+if goat_is_inside_isaac_container; then
   exec "$container_script" "$@"
 fi
 
-export TERM="${TERM:-xterm}"
-launcher="$(resolve_isaac_launcher)"
+if [[ ! -f "$workspace_setup" ]]; then
+  echo "Workspace setup file not found at $workspace_setup." >&2
+  echo "Run ./scripts/dev/build.sh first." >&2
+  exit 1
+fi
 
-exec "$launcher" -d "$repo_root" -- /workspaces/isaac_ros-dev/scripts/ops/_run_vslam_demo_in_container.sh "$@"
+export TERM="${TERM:-xterm}"
+goat_exec_in_isaac_container "$container_script_in_workspace" "$@"

--- a/scripts/ops/run_vslam_demo.sh
+++ b/scripts/ops/run_vslam_demo.sh
@@ -3,8 +3,8 @@
 #
 # Purpose:
 #   Dispatch to the container-local demo launcher. From the host this launches
-#   or reuses the Isaac ROS container; from inside the container it launches
-#   directly without re-running host Docker checks.
+#   or reuses the Isaac ROS dev container through upstream `run_dev.sh`; from
+#   inside the container it launches directly.
 #
 # Inputs:
 #   Optional extra `ros2 launch` arguments forwarded to
@@ -44,4 +44,4 @@ if [[ ! -f "$workspace_setup" ]]; then
 fi
 
 export TERM="${TERM:-xterm}"
-goat_exec_in_isaac_container "$container_script_in_workspace" "$@"
+goat_run_in_isaac_dev "$container_script_in_workspace" "$@"


### PR DESCRIPTION
## Summary
- restore the supported GOAT workflow around upstream Isaac ROS `run_dev.sh` so host `bootstrap.sh`, `build.sh`, and `run_vslam_demo.sh` invocations execute their intended container-side work instead of dropping into an interactive shell
- add shared Isaac container helpers plus a dedicated `./scripts/dev/enter.sh` path for manual ROS operations inside the same upstream-managed container
- sync repo-owned Isaac config and Docker args into the vendored Isaac scripts during bootstrap, and add a GOAT overlay image layer that preinstalls `isaac_ros_visual_slam`, `rviz2`, X11 helpers, and the required GXF serialization library path
- update the top-level and Isaac workflow docs to describe the supported bootstrap/build/demo/enter flow and manual Jetson desktop debugging path

## Included Changes
- centralize Isaac container detection, safe setup sourcing, support-file sync, and `run_dev.sh` handoff in `scripts/_lib/isaac_container.sh`
- move bootstrap's in-container dependency install into `scripts/dev/_bootstrap_in_container.sh`
- make `scripts/dev/build.sh` and `scripts/ops/run_vslam_demo.sh` reuse upstream `run_dev.sh` for host-side entry while keeping direct in-container execution intact
- add `scripts/dev/enter.sh` as the explicit interactive-shell entrypoint for topic inspection, `rviz2`, and other manual ROS debugging
- align `.isaac_ros_common-config`, `.isaac_ros_dev-dockerargs`, `docker/Dockerfile.goat`, `README.md`, and the Isaac docs with the GOAT overlay image flow

## Validation
- `bash -n scripts/dev/bootstrap.sh scripts/dev/build.sh scripts/dev/_bootstrap_in_container.sh scripts/dev/_build_in_container.sh scripts/dev/enter.sh scripts/ops/run_vslam_demo.sh scripts/ops/_run_vslam_demo_in_container.sh scripts/_lib/isaac_container.sh`
- `git diff --check`
- `env ISAAC_ROS_WS=/workspaces/isaac_ros-dev bash scripts/dev/bootstrap.sh`

## Notes
- This follows up on #27.
- GitHub currently shows no configured check runs on this PR.
- I did not run the full Docker build/demo workflow in this environment.
